### PR TITLE
Bump dask and distributed minimum versions to 2.2.0

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -1,21 +1,21 @@
-cloudprovider:
+cloudprovider: {}
 
-  ecs:
-    scheduler_cpu: 1024  # Millicpu (1024ths of a CPU core)
-    scheduler_mem: 4096  # Memory in MB
-    worker_cpu: 4096  # Millicpu (1024ths of a CPU core)
-    worker_mem: 16384  # Memory in MB
-    n_workers: 2
+  # ecs: {}
+  #   # scheduler_cpu: 1024  # Millicpu (1024ths of a CPU core)
+  #   # scheduler_mem: 4096  # Memory in MB
+  #   # worker_cpu: 4096  # Millicpu (1024ths of a CPU core)
+  #   # worker_mem: 16384  # Memory in MB
+  #   # n_workers: 2
 
-    image: 'daskdev/dask:1.2.0'
-    cluster_name_template: 'dask-{uuid}'  # Template to use when creating a cluster
-    cluster_arn: null  # ARN of existing ECS cluster to use (if not set one will be created)
-    execution_role_arn: null  # Arn of existing execution role to use (if not set one will be created)
-    task_role_arn: null  # Arn of existing task role to use (if not set one will be created)
+  #   # image: 'daskdev/dask:1.2.0'
+  #   # cluster_name_template: 'dask-{uuid}'  # Template to use when creating a cluster
+  #   # cluster_arn: null  # ARN of existing ECS cluster to use (if not set one will be created)
+  #   # execution_role_arn: null  # Arn of existing execution role to use (if not set one will be created)
+  #   # task_role_arn: null  # Arn of existing task role to use (if not set one will be created)
 
-    cloudwatch_logs_group: null  # Name of existing cloudwatch logs group to use (if not set one will be created)
-    cloudwatch_logs_stream_prefix: '{cluster_name}'  # Stream prefix template
-    cloudwatch_logs_default_retention: 30  # Number of days to retain logs (only applied if not using existing group)
+  #   # cloudwatch_logs_group: null  # Name of existing cloudwatch logs group to use (if not set one will be created)
+  #   # cloudwatch_logs_stream_prefix: '{cluster_name}'  # Stream prefix template
+  #   # cloudwatch_logs_default_retention: 30  # Number of days to retain logs (only applied if not using existing group)
 
-    vpc: default  # VPC to use for tasks
-    security_groups: [] # Security groups to use (if not set one will be created)
+  #   # vpc: default  # VPC to use for tasks
+  #   # security_groups: [] # Security groups to use (if not set one will be created)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiobotocore>=0.10.2
-dask>=0.19.0
-distributed>=1.22.0
+dask>=2.2.0
+distributed>=2.2.0


### PR DESCRIPTION
This library requires some changes that went into distributed 2.2.0. Bumping minimum versions here to be safe.

Closes #18 