### PR TITLE
add get last possible value from task arn

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -257,7 +257,7 @@ class Task:
 
     @property
     def task_id(self):
-        return self.task_arn.split("/")[1]
+        return self.task_arn.split("/")[-1]
 
     @property
     def _log_stream_name(self):


### PR DESCRIPTION
Current method of getting the task id assumes that the task ID is the second value in a split of the task_arn on /.

Our task ARN looks like this:
arn:aws:ecs:<REGION>:<ACCT_ID>:task/<CLUSTER_NAME>/<TASK_ID>

I cannot validate what the original was assumed to look like but getting the last value from the split should work for both as the task ID should be the last value in the list always.