### PR TITLE
Add address timeout config

### DIFF
--- a/dask_cloudprovider/cli/ecs.py
+++ b/dask_cloudprovider/cli/ecs.py
@@ -137,6 +137,12 @@ logger = logging.getLogger(__name__)
     multiple=True,
     help="Tag to apply to all resources created automatically in the form FOO=bar (can be used multiple times)",
 )
+@click.option(
+    "--find-address-timeout",
+    type=int,
+    default=None,
+    help="Configurable timeout in seconds for finding the task IP from the cloudwatch logs.",
+)
 @click.option("--skip_cleanup", is_flag=True, help="Skip cleanup of stale resources")
 @click.version_option()
 def main(
@@ -163,6 +169,7 @@ def main(
     security_group,
     environment,
     tag,
+    find_address_timeout,
     skip_cleanup,
 ):
     tag = {v.split("=")[0]: v.split("=")[1] for v in tag} if tag else None

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -28,4 +28,5 @@ cloudprovider:
 
     tags: {} # Tags to apply to all AWS resources created by the cluster manager
     environment: {} # Environment variables that are set within a task container
+    find_address_timeout: 60 # Configurable timeout in seconds for finding the task IP from the cloudwatch logs.
     skip_cleanup: False # Skip cleaning up of stale resources

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -69,7 +69,6 @@ class Task:
         Configurable timeout in seconds for finding the task IP from the
         cloudwatch logs.
 
-        Defaults to 60 seconds.
     kwargs:
         Any additional kwargs which may need to be stored for later use.
 
@@ -91,7 +90,7 @@ class Task:
         fargate,
         environment,
         tags,
-        find_address_timeout=60,
+        find_address_timeout,
         name=None,
         **kwargs
     ):
@@ -711,6 +710,7 @@ class ECSCluster(SpecCluster):
             "log_stream_prefix": self._cloudwatch_logs_stream_prefix,
             "environment": self._environment,
             "tags": self.tags,
+            "find_address_timeout": self._find_address_timeout,
         }
         scheduler_options = {
             "task_definition_arn": self.scheduler_task_definition_arn,

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -534,7 +534,7 @@ class ECSCluster(SpecCluster):
         security_groups=None,
         environment=None,
         tags=None,
-        find_address_timeout=None
+        find_address_timeout=None,
         skip_cleanup=None,
         **kwargs
     ):

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -158,7 +158,7 @@ class Task:
 
     async def _set_address_from_logs(self):
         timeout = Timeout(
-            self._find_address_timeout, "Failed to find %s ip address after 30 seconds." % self._find_address_timeout
+            self._find_address_timeout, "Failed to find ip address after %s seconds." % self._find_address_timeout
         )
         while timeout.run():
             async for line in self.logs():

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -69,7 +69,7 @@ class Task:
         Configurable timeout in seconds for finding the scheduler IP from the
         cloudwatch logs.
 
-        Defaults to 60 seconds
+        Defaults to 60 seconds.
     kwargs:
         Any additional kwargs which may need to be stored for later use.
 
@@ -158,7 +158,10 @@ class Task:
 
     async def _set_address_from_logs(self):
         timeout = Timeout(
-            self._find_address_timeout, "Failed to find ip address after %s seconds." % self._find_address_timeout
+            self._find_address_timeout,
+            "Failed to find {} ip address after {} seconds.".format(
+                self.task_type, self._find_address_timeout
+            ),
         )
         while timeout.run():
             async for line in self.logs():
@@ -495,7 +498,7 @@ class ECSCluster(SpecCluster):
         Configurable timeout in seconds for finding the scheduler IP from the
         cloudwatch logs.
 
-        Defaults to 60 seconds
+        Defaults to 60 seconds.
     skip_cleanup: bool (optional)
         Skip cleaning up of stale resources. Useful if you have lots of resources
         and this operation takes a while.

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -66,7 +66,7 @@ class Task:
         AWS resource tags to be applied to any resources that are created.
 
     find_address_timeout: int
-        Configurable timeout in seconds for finding the scheduler IP from the
+        Configurable timeout in seconds for finding the task IP from the
         cloudwatch logs.
 
         Defaults to 60 seconds.
@@ -495,7 +495,7 @@ class ECSCluster(SpecCluster):
 
         Defaults to ``None``. Tags will always include ``{"createdBy": "dask-cloudprovider"}``
     find_address_timeout: int
-        Configurable timeout in seconds for finding the scheduler IP from the
+        Configurable timeout in seconds for finding the task IP from the
         cloudwatch logs.
 
         Defaults to 60 seconds.


### PR DESCRIPTION
Adds a configuration for finding the task (mostly for the scheduler) address timeout. A 30 second timeout is too short for when you add in extra conda or pip packages. The user should be able to extend this time to as long as they require