### PR TITLE
adds exponential backoff to get_log_events

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -12,7 +12,11 @@ import dask
 
 from dask_cloudprovider.utils.logs import Log, Logs
 from dask_cloudprovider.utils.timeout import Timeout
-from dask_cloudprovider.providers.aws.helper import dict_to_aws, aws_to_dict
+from dask_cloudprovider.providers.aws.helper import (
+    dict_to_aws,
+    aws_to_dict,
+    get_sleep_duration,
+)
 
 from distributed.deploy.spec import SpecCluster
 from distributed.utils import warn_on_duration
@@ -271,33 +275,47 @@ class Task:
         )
 
     async def logs(self, follow=False):
+        current_try = 0
         next_token = None
         read_from = 0
+
         while True:
-            if next_token:
-                l = await self._clients["logs"].get_log_events(
-                    logGroupName=self.log_group,
-                    logStreamName=self._log_stream_name,
-                    nextToken=next_token,
-                )
-            else:
-                l = await self._clients["logs"].get_log_events(
-                    logGroupName=self.log_group,
-                    logStreamName=self._log_stream_name,
-                    startTime=read_from,
-                )
-            if next_token != l["nextForwardToken"]:
-                next_token = l["nextForwardToken"]
-            else:
-                next_token = None
-            if not l["events"]:
-                if follow:
-                    await asyncio.sleep(1)
+            try:
+                if next_token:
+                    l = await self._clients["logs"].get_log_events(
+                        logGroupName=self.log_group,
+                        logStreamName=self._log_stream_name,
+                        nextToken=next_token,
+                    )
                 else:
-                    break
-            for event in l["events"]:
-                read_from = event["timestamp"]
-                yield event["message"]
+                    l = await self._clients["logs"].get_log_events(
+                        logGroupName=self.log_group,
+                        logStreamName=self._log_stream_name,
+                        startTime=read_from,
+                    )
+                if next_token != l["nextForwardToken"]:
+                    next_token = l["nextForwardToken"]
+                else:
+                    next_token = None
+                if not l["events"]:
+                    if follow:
+                        await asyncio.sleep(1)
+                    else:
+                        break
+                for event in l["events"]:
+                    read_from = event["timestamp"]
+                    yield event["message"]
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "ThrottlingException":
+                    warnings.warn(
+                        "get_log_events rate limit exceeded, retrying after delay.",
+                        RuntimeWarning,
+                    )
+                    backoff_duration = get_sleep_duration(current_try)
+                    await asyncio.sleep(backoff_duration)
+                    current_try += 1
+                else:
+                    raise
 
     def __repr__(self):
         return "<ECS Task %s: status=%s>" % (type(self).__name__, self.status)

--- a/dask_cloudprovider/providers/aws/helper.py
+++ b/dask_cloudprovider/providers/aws/helper.py
@@ -12,3 +12,10 @@ def aws_to_dict(aws_dict):
         return {item["key"]: item["value"] for item in aws_dict}
     except KeyError:
         return {item["Key"]: item["Value"] for item in aws_dict}
+
+
+# https://aws.amazon.com/blogs/messaging-and-targeting/how-to-handle-a-throttling-maximum-sending-rate-exceeded-error/
+def get_sleep_duration(current_try, min_sleep_millis=10, max_sleep_millis=5000):
+    current_try = max(1, current_try)
+    current_sleep_millis = min_sleep_millis * current_try ** 2
+    return min(current_sleep_millis, max_sleep_millis) / 1000  # return in seconds

--- a/dask_cloudprovider/providers/aws/tests/test_helper.py
+++ b/dask_cloudprovider/providers/aws/tests/test_helper.py
@@ -13,3 +13,30 @@ def test_aws_to_dict_and_back():
     assert aws_to_dict(dict_to_aws(py_dict)) == py_dict
     assert dict_to_aws(aws_to_dict(aws_dict)) == aws_dict
     assert dict_to_aws(aws_to_dict(aws_upper_dict), upper=True) == aws_upper_dict
+
+
+def test_get_sleep_duration_first_try():
+    from dask_cloudprovider.providers.aws.helper import get_sleep_duration
+
+    duration = get_sleep_duration(
+        current_try=0, min_sleep_millis=10, max_sleep_millis=5000
+    )
+    assert duration == 0.01
+
+
+def test_get_sleep_duration_max():
+    from dask_cloudprovider.providers.aws.helper import get_sleep_duration
+
+    duration = get_sleep_duration(
+        current_try=23, min_sleep_millis=10, max_sleep_millis=5000
+    )
+    assert duration == 5.0
+
+
+def test_get_sleep_duration_negative_try():
+    from dask_cloudprovider.providers.aws.helper import get_sleep_duration
+
+    duration = get_sleep_duration(
+        current_try=-1, min_sleep_millis=10, max_sleep_millis=5000
+    )
+    assert duration == 0.01


### PR DESCRIPTION
**Fixes**
https://github.com/dask/dask-cloudprovider/issues/34

**What**
Adds exponential backoff to get_log_events along with a warning message that this is happening. Max backoff is set at 5 seconds

Adapted from:
https://aws.amazon.com/blogs/messaging-and-targeting/how-to-handle-a-throttling-maximum-sending-rate-exceeded-error/