### PR TITLE
Fix unable to create Security Group in non-default VPC

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -942,7 +942,7 @@ class ECSCluster(SpecCluster):
                     "IpProtocol": "TCP",
                     "FromPort": 0,
                     "ToPort": 65535,
-                    "UserIdGroupPairs": [{"GroupName": self.cluster_name}],
+                    "UserIdGroupPairs": [{"GroupId": response["GroupId"]}],
                 },
             ],
             DryRun=False,


### PR DESCRIPTION
When launching a FarGate cluster on a non-default VPC, the automatic Security Group Creation fails as shown below.

This occurs because the ingress rules are referencing the security group by GroupName, however to reference a security group in a non-default VPC you are required to use GroupId. See [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.authorize_security_group_ingress).

Easy fix, just need to reference the newly created SG by GroupId instead of GroupName.

```
~/SageMaker/myenvs/pangeo/lib/python3.6/site-packages/dask_cloudprovider/providers/aws/ecs.py in _start(self)
    720             self._security_groups = (
    721                 self.config.get("security_groups")
--> 722                 or await self._create_security_groups()
    723             )
    724 

~/SageMaker/myenvs/pangeo/lib/python3.6/site-packages/dask_cloudprovider/providers/aws/ecs.py in _create_security_groups(self)
    946                 },
    947             ],
--> 948             DryRun=False,
    949         )
    950         await self._clients["ec2"].create_tags(

~/SageMaker/myenvs/pangeo/lib/python3.6/site-packages/aiobotocore/client.py in _make_api_call(self, operation_name, api_params)
    100             error_code = parsed_response.get("Error", {}).get("Code")
    101             error_class = self.exceptions.from_code(error_code)
--> 102             raise error_class(parsed_response, operation_name)
    103         else:
    104             return parsed_response

ClientError: An error occurred (InvalidGroup.NotFound) when calling the AuthorizeSecurityGroupIngress operation: The security group 'dask-540389cd-c' does not exist in default VPC 'none'

```