### PR TITLE
Support avoiding use of a public IP with Fargate

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -73,6 +73,12 @@ class Task:
         Configurable timeout in seconds for finding the task IP from the
         cloudwatch logs.
 
+    name: str (optional)
+        Name for used for the --name argument to dask-worker command line
+
+    use_private_ip: bool (optional)
+        Whether to use a private IP (if True) or public IP (if False). Default is False.
+
     kwargs:
         Any additional kwargs which may need to be stored for later use.
 
@@ -137,7 +143,7 @@ class Task:
 
     @property
     def _use_public_ip(self):
-        return not self._use_private_ip
+        return self.fargate and not self._use_private_ip
 
     async def _is_long_arn_format_enabled(self):
         async with self._client("ecs") as ecs:
@@ -521,7 +527,7 @@ class ECSCluster(SpecCluster):
 
         Default ``False``.
     use_private_ip: bool (optional)
-        Avoid using a public IP address, e.g. with a private subnet VPC.
+        If True, use a private IP, if False use public IPs.
 
         Default ``False``.
     **kwargs: dict

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -745,7 +745,7 @@ class ECSCluster(SpecCluster):
             "environment": self._environment,
             "tags": self.tags,
             "find_address_timeout": self._find_address_timeout,
-            "use_private_ip": self._use_private_ip
+            "use_private_ip": self._use_private_ip,
         }
         scheduler_options = {
             "task_definition_arn": self.scheduler_task_definition_arn,

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -74,7 +74,7 @@ class Task:
         cloudwatch logs.
 
     name: str (optional)
-        Name for used for the --name argument to dask-worker command line
+        Name for the task. Currently used for the --namecommand line argument to dask-worker.
 
     use_private_ip: bool (optional)
         Whether to use a private IP (if True) or public IP (if False). Default is False.

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -76,8 +76,9 @@ class Task:
     name: str (optional)
         Name for the task. Currently used for the --namecommand line argument to dask-worker.
 
-    use_private_ip: bool (optional)
-        Whether to use a private IP (if True) or public IP (if False). Default is False.
+    fargate_use_private_ip: bool (optional)
+        Whether to use a private IP (if True) or public IP (if False) with Fargate.
+        Defaults to False, i.e. public IP.
 
     kwargs:
         Any additional kwargs which may need to be stored for later use.
@@ -102,7 +103,7 @@ class Task:
         tags,
         find_address_timeout,
         name=None,
-        use_private_ip=False,
+        fargate_use_private_ip=False,
         **kwargs
     ):
         self.lock = asyncio.Lock()
@@ -127,7 +128,7 @@ class Task:
         self.environment = environment or {}
         self.tags = tags
         self._find_address_timeout = find_address_timeout
-        self._use_private_ip = use_private_ip
+        self._fargate_use_private_ip = fargate_use_private_ip
         self.kwargs = kwargs
         self.status = "created"
 
@@ -143,7 +144,7 @@ class Task:
 
     @property
     def _use_public_ip(self):
-        return self.fargate and not self._use_private_ip
+        return self.fargate and not self._fargate_use_private_ip
 
     async def _is_long_arn_format_enabled(self):
         async with self._client("ecs") as ecs:
@@ -526,9 +527,9 @@ class ECSCluster(SpecCluster):
         and this operation takes a while.
 
         Default ``False``.
-    use_private_ip: bool (optional)
-        If True, use a private IP, if False use public IPs.
-
+    fargate_use_private_ip: bool (optional)
+        Whether to use a private IP (if True) or public IP (if False) with Fargate.
+        
         Default ``False``.
     **kwargs: dict
         Additional keyword arguments to pass to ``SpecCluster``.
@@ -568,7 +569,7 @@ class ECSCluster(SpecCluster):
         aws_access_key_id=None,
         aws_secret_access_key=None,
         region_name=None,
-        use_private_ip=False,
+        fargate_use_private_ip=False,
         **kwargs
     ):
         self._fargate_scheduler = fargate_scheduler
@@ -597,7 +598,7 @@ class ECSCluster(SpecCluster):
         self._tags = tags
         self._find_address_timeout = find_address_timeout
         self._skip_cleanup = skip_cleanup
-        self._use_private_ip = use_private_ip
+        self._fargate_use_private_ip = fargate_use_private_ip
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key
         self._region_name = region_name
@@ -751,7 +752,7 @@ class ECSCluster(SpecCluster):
             "environment": self._environment,
             "tags": self.tags,
             "find_address_timeout": self._find_address_timeout,
-            "use_private_ip": self._use_private_ip,
+            "fargate_use_private_ip": self._fargate_use_private_ip,
         }
         scheduler_options = {
             "task_definition_arn": self.scheduler_task_definition_arn,


### PR DESCRIPTION
Previously, a Fargate cluster would always use a public IP. For organizations with security and compliance constraints, they would need to use Fargate with a private subnet in a VPC that isn't reachable from the public Internet.