### PR TITLE
(WIP) Adding in to policy for minimal IAM permissions

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -100,6 +100,7 @@ Here is the full minimal IAM policy that you need to create the whole cluster:
                    "ec2:DescribeNetworkInterfaces",
                    "ec2:DescribeSubnets",
                    "ec2:DescribeVpcs",
+                   "ec2:DescribeSecurityGroups",
                    "ec2:DeleteSecurityGroup",
                    "ecs:CreateCluster",
                    "ecs:DescribeTasks",
@@ -115,13 +116,17 @@ Here is the full minimal IAM policy that you need to create the whole cluster:
                    "ecs:DeregisterTaskDefinition",
                    "iam:AttachRolePolicy",
                    "iam:CreateRole",
+                   "iam:CreateServiceLinkedRole",
                    "iam:TagRole",
                    "iam:PassRole",
                    "iam:DeleteRole",
                    "iam:ListRoleTags",
+                   "iam:ListRoles",
                    "iam:ListAttachedRolePolicies",
                    "iam:DetachRolePolicy",
-                   "logs:DescribeLogGroups"
+                   "logs:DescribeLogGroups",
+                   "logs:CreateLogGroup",
+                   "logs:PutRetentionPolicy"
                ],
                "Effect": "Allow",
                "Resource": [


### PR DESCRIPTION
When trying to use Dask Cloud Provider today to startup a `FargateCluster` with a fresh new IAM user sporting the minimal policy referred to in the docs, I got hit by a couple of explicit permission errors by the AWS client. This PR simply adds them in as I run into them until I can create a `FargateCluster` out of the box with only the minimal IAM policy.

This is still a WIP since I am still getting stuck regarding 'service linked roles', which is not providing explicit permission errors as the others, but instead this more vague error:

```
InvalidParameterException: An error occurred (InvalidParameterException) when calling the RunTask operation: Unable to assume the service linked role. Please verify that the ECS service linked role exists.
```

Some quick research elsewhere indicates people expect an AWS admin to create the service linked role in at least some other cases where it did not successfully autoprovision (github issue at https://github.com/aws/amazon-ecs-cli/issues/733, a related stack overflow discussion [here](https://stackoverflow.com/questions/54877475/unable-to-assume-service-linked-role-when-using-ecs-cli)), but since I believe the point of Dask Cloud Provider is to spin everything up with "no hands", I think it's worth figuring out what missing client calls or permissions are missing in the minimal setup for this to autocreate as expected.