### PR TITLE
Allow extra command line args to scheduler & worker

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -4,9 +4,11 @@ cloudprovider:
     fargate_workers: False # Use fargate mode for the workers
     scheduler_cpu: 1024 # Millicpu (1024ths of a CPU core)
     scheduler_mem: 4096 # Memory in MB
+#   scheduler_extra_args: "--tls-cert,/path/to/cert.pem,--tls-key,/path/to/cert.key,--tls-ca-file,/path/to/ca.key"
     worker_cpu: 4096 # Millicpu (1024ths of a CPU core)
     worker_mem: 16384 # Memory in MB
     worker_gpu: 0 # Number of GPUs for each worker
+#   worker_extra_args: "--tls-cert,/path/to/cert.pem,--tls-key,/path/to/cert.key,--tls-ca-file,/path/to/ca.key"
     n_workers: 0 # Number of workers to start the cluster with
     scheduler_timeout: "5 minutes" # Length of inactivity to wait before closing the cluster
 

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -384,7 +384,8 @@ class Worker(Task):
                 "{}GB".format(int(self._mem / 1024)),
                 "--death-timeout",
                 "60",
-            ] + (list() if not extra_args else extra_args)
+            ]
+            + (list() if not extra_args else extra_args)
         }
 
 
@@ -1018,7 +1019,12 @@ class ECSCluster(SpecCluster):
                             "dask-scheduler",
                             "--idle-timeout",
                             self._scheduler_timeout,
-                        ] + (list() if not self._scheduler_extra_args else self._scheduler_extra_args),
+                        ]
+                        + (
+                            list()
+                            if not self._scheduler_extra_args
+                            else self._scheduler_extra_args
+                        ),
                         "logConfiguration": {
                             "logDriver": "awslogs",
                             "options": {
@@ -1074,7 +1080,12 @@ class ECSCluster(SpecCluster):
                             "{}MB".format(int(self._worker_mem)),
                             "--death-timeout",
                             "60",
-                        ] + (list() if not self._worker_extra_args else self._worker_extra_args),
+                        ]
+                        + (
+                            list()
+                            if not self._worker_extra_args
+                            else self._worker_extra_args
+                        ),
                         "logConfiguration": {
                             "logDriver": "awslogs",
                             "options": {

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -597,7 +597,6 @@ class ECSCluster(SpecCluster):
         self._worker_mem = worker_mem
         self._worker_gpu = worker_gpu
         self._worker_extra_args = worker_extra_args
-        self._worker_extra_args = worker_extra_args
         self._n_workers = n_workers
         self.cluster_arn = cluster_arn
         self.cluster_name = None
@@ -681,7 +680,10 @@ class ECSCluster(SpecCluster):
             self._scheduler_timeout = self.config.get("scheduler_timeout")
 
         if self._scheduler_extra_args is None:
-            self._scheduler_extra_args = self.config.get("scheduler_extra_args")
+            comma_separated_args = self.config.get("scheduler_extra_args")
+            self._scheduler_extra_args = (
+                comma_separated_args.split(",") if comma_separated_args else None
+            )
 
         if self._worker_cpu is None:
             self._worker_cpu = self.config.get("worker_cpu")
@@ -690,7 +692,10 @@ class ECSCluster(SpecCluster):
             self._worker_mem = self.config.get("worker_mem")
 
         if self._worker_extra_args is None:
-            self._worker_extra_args = self.config.get("worker_extra_args")
+            comma_separated_args = self.config.get("worker_extra_args")
+            self._worker_extra_args = (
+                comma_separated_args.split(",") if comma_separated_args else None
+            )
 
         if self._n_workers is None:
             self._n_workers = self.config.get("n_workers")


### PR DESCRIPTION
In order to support TLS encryption, we need to be able to pass command line arguments like `--tls-cert`, `--tls-key`, etc. to both dask-scheduler and dask-worker. This PR allows for arbitrary
additional command line arguments, so that any valid command line args to dask-scheduler and dask-worker are supported.