### PR TITLE
Support for Fargate Spot Capacity Provider

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -867,22 +867,22 @@ class ECSCluster(SpecCluster):
             self._cluster_name_template
         )
         self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
-        create_cluster_kwargs = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
+        create_cluster_kwargs = {
+            "clusterName": self.cluster_name,
+            "tags": dict_to_aws(self.tags),
+        }
         if self._fargate_spot:
             spot_cluster_kwargs = {
-                'capacityProviders': ['FARGATE', 'FARGATE_SPOT'],
-                'defaultCapacityProviderStrategy': [
+                "capacityProviders": ["FARGATE", "FARGATE_SPOT"],
+                "defaultCapacityProviderStrategy": [
                     {
-                        'capacityProvider': 'FARGATE_SPOT',
-                        'weight': self._fargate_spot_weight
+                        "capacityProvider": "FARGATE_SPOT",
+                        "weight": self._fargate_spot_weight,
                     },
-                    {
-                        'capacityProvider': 'FARGATE',
-                        'weight': 1
-                    },
-                ]
+                    {"capacityProvider": "FARGATE", "weight": 1},
+                ],
             }
-            create_cluster_kwargs = { **create_cluster_kwargs, **spot_cluster_kwargs}
+            create_cluster_kwargs = {**create_cluster_kwargs, **spot_cluster_kwargs}
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(**create_cluster_kwargs)
         weakref.finalize(self, self.sync, self._delete_cluster)

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -872,7 +872,8 @@ class ECSCluster(SpecCluster):
             "tags": dict_to_aws(self.tags),
         }
         if self._fargate_spot:
-            spot_cluster_kwargs = {
+            create_cluster_kwargs = {
+                **create_cluster_kwargs,
                 "capacityProviders": ["FARGATE", "FARGATE_SPOT"],
                 "defaultCapacityProviderStrategy": [
                     {
@@ -882,7 +883,6 @@ class ECSCluster(SpecCluster):
                     {"capacityProvider": "FARGATE", "weight": 1},
                 ],
             }
-            create_cluster_kwargs = {**create_cluster_kwargs, **spot_cluster_kwargs}
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(**create_cluster_kwargs)
         weakref.finalize(self, self.sync, self._delete_cluster)

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -866,9 +866,9 @@ class ECSCluster(SpecCluster):
         self.cluster_name = dask.config.expand_environment_variables(
             self._cluster_name_template
         )
-        create_cluster_args = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
+        create_cluster_kwargs = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
         if self._fargate_spot:
-            spot_cluster_args = {
+            spot_cluster_kwargs = {
                 'capacityProviders': ['FARGATE', 'FARGATE_SPOT'],
                 'defaultCapacityProviderStrategy': [
                     {
@@ -881,10 +881,10 @@ class ECSCluster(SpecCluster):
                     },
                 ]
             }
-            create_cluster_args = { **create_cluster_args, **spot_cluster_args}
+            create_cluster_kwargs = { **create_cluster_kwargs, **spot_cluster_kwargs}
         self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         async with self._client("ecs") as ecs:
-            response = await ecs.create_cluster(**create_cluster_args)
+            response = await ecs.create_cluster(**create_cluster_kwargs)
         weakref.finalize(self, self.sync, self._delete_cluster)
         return response["cluster"]["clusterArn"]
 

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -866,6 +866,7 @@ class ECSCluster(SpecCluster):
         self.cluster_name = dask.config.expand_environment_variables(
             self._cluster_name_template
         )
+        self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         create_cluster_kwargs = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
         if self._fargate_spot:
             spot_cluster_kwargs = {
@@ -882,7 +883,6 @@ class ECSCluster(SpecCluster):
                 ]
             }
             create_cluster_kwargs = { **create_cluster_kwargs, **spot_cluster_kwargs}
-        self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(**create_cluster_kwargs)
         weakref.finalize(self, self.sync, self._delete_cluster)

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -415,14 +415,14 @@ class ECSCluster(SpecCluster):
         Select whether or not to use fargate for the workers.
 
         Defaults to ``False``. You must provide an existing cluster.
-	fargate_spot: bool (optional)
-	    Select whether or not to include ``FARGATE_SPOT`` Capacity Provider
-		
-		Defaults to ``False``.
-	fargate_spot_weight: int (optional)
-	    Specifies ``FARGATE_SPOT`` Capacity Provider Weight.
-		
-		Defaults to ``4``.
+    fargate_spot: bool (optional)
+        Select whether or not to include ``FARGATE_SPOT`` Capacity Provider
+
+        Defaults to ``False``.
+    fargate_spot_weight: int (optional)
+        Specifies ``FARGATE_SPOT`` Capacity Provider Weight.
+
+        Defaults to ``4``.
     image: str (optional)
         The docker image to use for the scheduler and worker tasks.
 
@@ -583,8 +583,8 @@ class ECSCluster(SpecCluster):
         self,
         fargate_scheduler=False,
         fargate_workers=False,
-		fargate_spot=False,
-		fargate_spot_weight=4,
+        fargate_spot=False,
+        fargate_spot_weight=4,
         image=None,
         scheduler_cpu=None,
         scheduler_mem=None,
@@ -619,8 +619,8 @@ class ECSCluster(SpecCluster):
     ):
         self._fargate_scheduler = fargate_scheduler
         self._fargate_workers = fargate_workers
-		self._fargate_spot = fargate_spot
-		self._fargate_spot_weight = fargate_spot_weight
+        self._fargate_spot = fargate_spot
+        self._fargate_spot_weight = fargate_spot_weight
         self.image = image
         self._scheduler_cpu = scheduler_cpu
         self._scheduler_mem = scheduler_mem
@@ -684,10 +684,10 @@ class ECSCluster(SpecCluster):
             self._fargate_scheduler = self.config.get("fargate_scheduler")
         if self._fargate_workers is None:
             self._fargate_workers = self.config.get("fargate_workers")
-		if self._fargate_spot is None:
-		    self._fargate_spot = self.config.get("fargate_spot")
-		if self._fargate_spot_weight is None:
-		    self._fargate_spot_weight = self.config.get("fargate_spot_weight")
+        if self._fargate_spot is None:
+            self._fargate_spot = self.config.get("fargate_spot")
+        if self._fargate_spot_weight is None:
+            self._fargate_spot_weight = self.config.get("fargate_spot_weight")
 
         if self._tags is None:
             self._tags = self.config.get("tags")
@@ -866,22 +866,22 @@ class ECSCluster(SpecCluster):
         self.cluster_name = dask.config.expand_environment_variables(
             self._cluster_name_template
         )
-		create_cluster_args = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
-		if self._fargate_spot:
-			spot_cluster_args = {
-			    'capacityProviders': ['FARGATE', 'FARGATE_SPOT'],
-				'defaultCapacityProviderStrategy': [
-				    {
-					    'capacityProvider': 'FARGATE_SPOT',
-						'weight': self._fargate_spot_weight
-					},
-					{
-					    'capacityProvider': 'FARGATE',
-						'weight': 1
-					},
-				]
-			}
-			create_cluster_args = { **create_cluster_args, **spot_cluster_args}
+        create_cluster_args = {'clusterName': self.cluster_name, 'tags': dict_to_aws(self.tags)}
+        if self._fargate_spot:
+            spot_cluster_args = {
+                'capacityProviders': ['FARGATE', 'FARGATE_SPOT'],
+                'defaultCapacityProviderStrategy': [
+                    {
+                        'capacityProvider': 'FARGATE_SPOT',
+                        'weight': self._fargate_spot_weight
+                    },
+                    {
+                        'capacityProvider': 'FARGATE',
+                        'weight': 1
+                    },
+                ]
+            }
+            create_cluster_args = { **create_cluster_args, **spot_cluster_args}
         self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(**create_cluster_args)

--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -415,6 +415,14 @@ class ECSCluster(SpecCluster):
         Select whether or not to use fargate for the workers.
 
         Defaults to ``False``. You must provide an existing cluster.
+	fargate_spot: bool (optional)
+	    Select whether or not to include ``FARGATE_SPOT`` Capacity Provider
+		
+		Defaults to ``False``.
+	fargate_spot_weight: int (optional)
+	    Specifies ``FARGATE_SPOT`` Capacity Provider Weight.
+		
+		Defaults to ``4``.
     image: str (optional)
         The docker image to use for the scheduler and worker tasks.
 


### PR DESCRIPTION
Per boto3 documentation:

> To use a AWS Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT capacity providers. The AWS Fargate capacity providers are available to all accounts and only need to be associated with a cluster to be used.

There's no need to have to issue a separate `createCapacityProvider` request. 

Defaults to a 4:1 ratio for Spot/OnDemand capacity. 

Initial attempt at addressing Issue #47 

Does not handle spot termination notices per #48 