### PR TITLE
Allowing explicit passing of the resource group for VNET

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ jobs:
             /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/py.test dask_cloudprovider
       - run:
           command: |
-            /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/flake8 dask-cloudprovider
+            /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/flake8 dask_cloudprovider
             /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/black --check dask_cloudprovider setup.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,5 +43,5 @@ jobs:
             /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/py.test dask_cloudprovider
       - run:
           command: |
-            /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/flake8 dask_cloudprovider
+            /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/flake8 dask-cloudprovider
             /home/circleci/miniconda/envs/dask-cloudprovider-test/bin/black --check dask_cloudprovider setup.py

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -115,6 +115,18 @@ class AzureMLCluster(Cluster):
 
         Defaults to ``""``.
 
+    vnet: str (optional)
+        Name of the virtual network.
+
+    subnet: str (optional)
+        Name of the subnet inside the virtual network ``vnet``.
+
+    vnet_resource_group: str (optional)
+        Name of the resource group where the virtual network ``vnet``
+        is located. If not passed, but names for ``vnet`` and ``subnet`` are
+        passed, ``vnet_resource_group`` is assigned with the name of resource
+        group associted with ``workspace``
+
     telemetry_opt_out: bool (optional)
         A boolean parameter. Defaults to logging a version of AzureMLCluster
         with Microsoft. Set this flag to False if you do not want to share this
@@ -147,6 +159,7 @@ class AzureMLCluster(Cluster):
         admin_ssh_key=None,
         datastores=None,
         code_store=None,
+        vnet_resource_group=None,
         vnet=None,
         subnet=None,
         show_output=False,
@@ -179,6 +192,7 @@ class AzureMLCluster(Cluster):
         ## CREATE COMPUTE TARGET
         self.admin_username = admin_username
         self.admin_ssh_key = admin_ssh_key
+        self.vnet_resource_group = vnet_resource_group
         self.vnet = vnet
         self.subnet = subnet
         self.compute_target_set = True
@@ -465,9 +479,12 @@ class AzureMLCluster(Cluster):
         ssh_key_pub, self.admin_ssh_key = self.__get_ssh_keys()
 
         if self.vnet and self.subnet:
-            vnet_rg = self.workspace.resource_group
             vnet_name = self.vnet
             subnet_name = self.subnet
+            if self.vnet_resource_group:
+                vnet_rg = self.vnet_resource_group
+            else:
+                vnet_rg = self.workspace.resource_group
 
         try:
             if ct_name not in self.workspace.compute_targets:
@@ -975,3 +992,4 @@ class AzureMLCluster(Cluster):
         return to its minimum number of nodes after its idle time before scaledown.
         """
         return self.sync(self._close)
+


### PR DESCRIPTION
This the PR for the first issue discussed in https://github.com/dask/dask-cloudprovider/issues/116

Now resource group name for VNET can be explicitly passed. If the resource group name for VNET is passed then that will be used while creating the VNET. If resource group name is not passed, but the names for VNET and SUBNET are passed, then resource group for the workspace will be used while creating the VNET.

Also added documentation for vnet, subnet, vnet_resource_group.

