### PR TITLE
fix typos in documentation

### DIFF
--- a/dask_cloudprovider/providers/aws/ecs.py
+++ b/dask_cloudprovider/providers/aws/ecs.py
@@ -353,7 +353,7 @@ class Task:
 
 
 class Scheduler(Task):
-    """ A Remote Dask Scheduler controled by ECS
+    """ A Remote Dask Scheduler controlled by ECS
 
     See :class:`Task` for parameter info.
     """
@@ -364,7 +364,7 @@ class Scheduler(Task):
 
 
 class Worker(Task):
-    """ A Remote Dask Worker controled by ECS
+    """ A Remote Dask Worker controlled by ECS
     Parameters
     ----------
     scheduler: str
@@ -544,7 +544,7 @@ class ECSCluster(SpecCluster):
         Extra environment variables to pass to the scheduler and worker tasks.
 
         Useful for setting ``EXTRA_APT_PACKAGES``, ``EXTRA_CONDA_PACKAGES`` and
-        ```EXTRA_PIP_PACKAGES`` if you'ree using the default image.
+        ```EXTRA_PIP_PACKAGES`` if you're using the default image.
 
         Defaults to ``None``.
     tags: dict (optional)

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -130,7 +130,7 @@ class AzureMLCluster(Cluster):
         Name of the resource group where the virtual network ``vnet``
         is located. If not passed, but names for ``vnet`` and ``subnet`` are
         passed, ``vnet_resource_group`` is assigned with the name of resource
-        group associted with ``workspace``
+        group associated with ``workspace``
 
     telemetry_opt_out: bool (optional)
         A boolean parameter. Defaults to logging a version of AzureMLCluster
@@ -972,7 +972,7 @@ class AzureMLCluster(Cluster):
         """
         for i in range(workers):
             if self.workers_list:
-                child_run = self.workers_list.pop(0)  # deactive oldest workers
+                child_run = self.workers_list.pop(0)  # deactivate oldest workers
                 child_run.complete()  # complete() will mark the run "Complete", but won't kill the process
                 child_run.cancel()
             else:

--- a/dask_cloudprovider/utils/timeout.py
+++ b/dask_cloudprovider/utils/timeout.py
@@ -32,7 +32,7 @@ class Timeout:
     ...     time.sleep(1)  # Will timeout after 10 iterations
     TimeoutException: Oh no! We timed out.
 
-    You can also pass an exception to raise if you are supressing for a set
+    You can also pass an exception to raise if you are suppressing for a set
     amount of time.
 
     >>> timeout = Timeout(10, "Oh no! We timed out.")

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -91,7 +91,7 @@ will be created automatically like in ``FargateCluster``.
 IAM Permissions
 ~~~~~~~~~~~~~~~
 
-To create a ``FargateCluster`` the cluster manager will need to various AWS resources ranging from IAM roles to VPCs to ECS tasks. Depending on your use case you may want the cluster to create all of these for you, or you may wish to specify them youself ahead of time.
+To create a ``FargateCluster`` the cluster manager will need to various AWS resources ranging from IAM roles to VPCs to ECS tasks. Depending on your use case you may want the cluster to create all of these for you, or you may wish to specify them yourself ahead of time.
 
 Here is the full minimal IAM policy that you need to create the whole cluster:
 


### PR DESCRIPTION
I'm just starting to get familiar with this project and wanted to find some small ways to contribute, so I ran `aspell` over this repo tonight. That turned up a handful of small typos in comments and documentation. This PR proposes fixing them.

Thanks for you time and consideration.