### PR TITLE
Add env_vars kwarg to VM cluster managers

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -36,6 +36,7 @@ class EC2Instance(VMInterface):
         bootstrap=None,
         ami=None,
         docker_image=None,
+        env_vars=None,
         instance_type=None,
         gpu_instance=None,
         vpc=None,
@@ -52,6 +53,7 @@ class EC2Instance(VMInterface):
         self.bootstrap = bootstrap
         self.ami = ami
         self.docker_image = docker_image or self.config.get("docker_image")
+        self.env_vars = env_vars
         self.instance_type = instance_type
         self.gpu_instance = gpu_instance
         self.vpc = vpc
@@ -105,6 +107,7 @@ class EC2Instance(VMInterface):
                     command=self.command,
                     gpu_instance=self.gpu_instance,
                     bootstrap=self.bootstrap,
+                    env_vars=self.env_vars,
                 ),
                 InstanceInitiatedShutdownBehavior="terminate",
                 NetworkInterfaces=[
@@ -241,6 +244,8 @@ class EC2Cluster(VMCluster):
         For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
 
         By default the ``daskdev/dask:latest`` image will be used.
+    env_vars: dict (optional)
+        Environment variables to be passed to the worker.
     silence_logs: bool
         Whether or not we should silence logging when setting up the cluster.
     asynchronous: bool

--- a/dask_cloudprovider/aws/tests/test_ec2.py
+++ b/dask_cloudprovider/aws/tests/test_ec2.py
@@ -181,8 +181,11 @@ async def test_get_ubuntu_image(ec2_client):
 
 @pytest.mark.asyncio
 async def test_get_cloud_init():
-    cloud_init = EC2Cluster.get_cloud_init()
+    cloud_init = EC2Cluster.get_cloud_init(
+        env_vars={"EXTRA_PIP_PACKAGES": "s3fs"},
+    )
     assert "systemctl start docker" in cloud_init
+    assert "-e EXTRA_PIP_PACKAGES=s3fs"
 
 
 @pytest.mark.asyncio

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -30,6 +30,7 @@ class Droplet(VMInterface):
         size: str = None,
         image: str = None,
         docker_image=None,
+        env_vars=None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -42,6 +43,7 @@ class Droplet(VMInterface):
         self.gpu_instance = False
         self.bootstrap = True
         self.docker_image = docker_image
+        self.env_vars = env_vars
 
     async def create_vm(self):
         self.droplet = digitalocean.Droplet(
@@ -56,6 +58,7 @@ class Droplet(VMInterface):
                 command=self.command,
                 gpu_instance=self.gpu_instance,
                 bootstrap=self.bootstrap,
+                env_vars=self.env_vars,
             ),
         )
         self.droplet.create()
@@ -127,6 +130,8 @@ class DropletCluster(VMCluster):
         For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
 
         By default the ``daskdev/dask:latest`` image will be used.
+    env_vars: dict (optional)
+        Environment variables to be passed to the worker.
     silence_logs: bool
         Whether or not we should silence logging when setting up the cluster.
     asynchronous: bool

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -54,6 +54,7 @@ class GCPInstance(VMInterface):
         filesystem_size=None,
         source_image=None,
         docker_image=None,
+        env_vars=None,
         ngpus=None,
         gpu_type=None,
         bootstrap=None,
@@ -69,6 +70,7 @@ class GCPInstance(VMInterface):
 
         self.source_image = source_image or self.config.get("source_image")
         self.docker_image = docker_image or self.config.get("docker_image")
+        self.env_vars = env_vars
         self.filesystem_size = filesystem_size or self.config.get("filesystem_size")
         self.ngpus = ngpus or self.config.get("ngpus")
         self.gpu_type = gpu_type or self.config.get("gpu_type")
@@ -174,6 +176,7 @@ class GCPInstance(VMInterface):
             gpu_instance=bool(self.ngpus),
             bootstrap=self.bootstrap,
             auto_shutdown=self.cluster.auto_shutdown,
+            env_vars=self.env_vars,
         )
 
         self.gcp_config = self.create_gcp_config()
@@ -373,6 +376,8 @@ class GCPCluster(VMCluster):
         Params to be passed to the worker class.
         See :class:`distributed.worker.Worker` for default worker class.
         If you set ``worker_class`` then refer to the docstring for the custom worker class.
+    env_vars: dict (optional)
+        Environment variables to be passed to the worker.
     scheduler_options: dict (optional)
         Params to be passed to the scheduler class.
         See :class:`distributed.scheduler.Scheduler`.

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -66,7 +66,7 @@ async def test_get_cloud_init():
 async def test_create_cluster():
     skip_without_credentials()
 
-    async with GCPCluster(asynchronous=True) as cluster:
+    async with GCPCluster(asynchronous=True, env_vars={"FOO": "bar"}) as cluster:
 
         assert cluster.status == Status.running
 
@@ -79,7 +79,13 @@ async def test_create_cluster():
             def inc(x):
                 return x + 1
 
+            def check_env():
+                import os
+
+                return os.environ["FOO"]
+
             assert await client.submit(inc, 10).result() == 11
+            assert await client.submit(check_env).result() == "bar"
 
 
 @pytest.mark.asyncio

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -43,7 +43,7 @@ runcmd:
   {% endif %}
 
   # Run container
-  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {{image}} {{ command }}'
+  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}={{env_vars[key]}} {% endfor %}{{image}} {{ command }}'
 
   {% if auto_shutdown %}
   # Shutdown when command is done

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -189,6 +189,7 @@ class VMCluster(SpecCluster):
         worker_options: dict = {},
         scheduler_options: dict = {},
         docker_image="daskdev/dask:latest",
+        env_vars: dict = {},
         **kwargs,
     ):
         if self.scheduler_class is None or self.worker_class is None:
@@ -198,6 +199,7 @@ class VMCluster(SpecCluster):
         self._n_workers = n_workers
         image = self.scheduler_options.get("docker_image", False) or docker_image
         self.scheduler_options["docker_image"] = image
+        self.worker_options["env_vars"] = env_vars
         self.worker_options["docker_image"] = image
         self.worker_options["worker_class"] = worker_class
         self.worker_options["worker_options"] = worker_options
@@ -247,4 +249,5 @@ class VMCluster(SpecCluster):
             gpu_instance=cluster.gpu_instance,
             bootstrap=cluster.bootstrap,
             auto_shutdown=cluster.auto_shutdown,
+            env_vars=cluster.worker_options["env_vars"],
         )

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -199,6 +199,7 @@ class VMCluster(SpecCluster):
         self._n_workers = n_workers
         image = self.scheduler_options.get("docker_image", False) or docker_image
         self.scheduler_options["docker_image"] = image
+        self.scheduler_options["env_vars"] = env_vars
         self.worker_options["env_vars"] = env_vars
         self.worker_options["docker_image"] = image
         self.worker_options["worker_class"] = worker_class


### PR DESCRIPTION
Add env_vars kwarg to VM cluster managers.

For example

```python
>>> from dask_cloudprovider.aws import EC2Cluster

>>> cluster = EC2Cluster(env_vars={"FOO": "bar"})
```

would result in the Docker command being generated as

```
docker run --net=host -e FOO=bar daskdev/dask:latest dask-worker <scheduler ip>
```

and then once you have connected a client you should be able to access it

```python
>>> import os
>>> from dask.distributed import Client

>>> client = Client(cluster)

>>> client.submit(lambda: os.environ["FOO"])
'bar'
```