### PR TITLE
Fix GPU flag for A100

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -168,12 +168,16 @@ class GCPInstance(VMInterface):
 
         return config
 
+    @property
+    def gpu_instance(self):
+        return "gpu" in self.machine_type or bool(self.ngpus)
+
     async def create_vm(self):
 
         self.cloud_init = self.cluster.render_cloud_init(
             image=self.docker_image,
             command=self.command,
-            gpu_instance=bool(self.ngpus),
+            gpu_instance=self.gpu_instance,
             bootstrap=self.bootstrap,
             auto_shutdown=self.cluster.auto_shutdown,
             env_vars=self.env_vars,


### PR DESCRIPTION
To use NVIDIA A100 GPUs on GCP you use either the `a2-highgpu` or `a2-megagpu` machine types instead of adding an accelerator.

For older GPUs including V100 and T4 you still specify an accelerator and the number of them to attach.

This PR ensured the cloud init is passed a correct `gpu_instance` regardless of the GPU selection method.