### PR TITLE
Fix bootstrapping on GCP

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -475,7 +475,7 @@ class GCPCluster(VMCluster):
         gpu_type=None,
         filesystem_size=None,
         auto_shutdown=None,
-        boostrap=True,
+        bootstrap=True,
         **kwargs,
     ):
 
@@ -489,6 +489,9 @@ class GCPCluster(VMCluster):
         )
         self.scheduler_class = GCPScheduler
         self.worker_class = GCPWorker
+        self.bootstrap = (
+            bootstrap if bootstrap is not None else self.config.get("bootstrap")
+        )
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -500,7 +503,7 @@ class GCPCluster(VMCluster):
             "machine_type": machine_type or self.config.get("machine_type"),
             "ngpus": ngpus or self.config.get("ngpus"),
             "gpu_type": gpu_type or self.config.get("gpu_type"),
-            "bootstrap": boostrap,
+            "bootstrap": self.bootstrap,
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -58,6 +58,7 @@ class GCPInstance(VMInterface):
         ngpus=None,
         gpu_type=None,
         bootstrap=None,
+        gpu_instance=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -74,7 +75,7 @@ class GCPInstance(VMInterface):
         self.filesystem_size = filesystem_size or self.config.get("filesystem_size")
         self.ngpus = ngpus or self.config.get("ngpus")
         self.gpu_type = gpu_type or self.config.get("gpu_type")
-        self.gpu_instance = "gpu" in self.machine_type or bool(self.ngpus)
+        self.gpu_instance = gpu_instance
         self.bootstrap = bootstrap
 
         self.general_zone = "-".join(self.zone.split("-")[:2])  # us-east1-c -> us-east1
@@ -492,6 +493,8 @@ class GCPCluster(VMCluster):
         self.bootstrap = (
             bootstrap if bootstrap is not None else self.config.get("bootstrap")
         )
+        self.machine_type = machine_type or self.config.get("machine_type")
+        self.gpu_instance = "gpu" in self.machine_type or bool(ngpus)
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -500,9 +503,10 @@ class GCPCluster(VMCluster):
             "docker_image": docker_image or self.config.get("docker_image"),
             "filesystem_size": filesystem_size or self.config.get("filesystem_size"),
             "zone": zone or self.config.get("zone"),
-            "machine_type": machine_type or self.config.get("machine_type"),
+            "machine_type": self.machine_type,
             "ngpus": ngpus or self.config.get("ngpus"),
             "gpu_type": gpu_type or self.config.get("gpu_type"),
+            "gpu_instance": self.gpu_instance,
             "bootstrap": self.bootstrap,
         }
         self.scheduler_options = {**self.options}

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -59,6 +59,7 @@ async def test_get_cloud_init():
 
     cloud_init = GCPCluster.get_cloud_init()
     assert "dask-scheduler" in cloud_init
+    assert "# Bootstrap" in cloud_init
 
 
 @pytest.mark.asyncio

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -39,7 +39,7 @@ runcmd:
 
   {% if bootstrap and gpu_instance %}
   # Install NVIDIA driver
-  - ubuntu-drivers install
+  - DEBIAN_FRONTEND=noninteractive ubuntu-drivers install
 
   # Install NVIDIA docker
   - curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -25,13 +25,6 @@ system_info:
     groups: [docker]
 {% endif %}
 
-{% if bootstrap and gpu_instance %}
-# Install NVIDIA driver if GPU instance
-drivers:
-  nvidia:
-    license-accepted: true
-{% endif %}
-
 runcmd:
   {% if bootstrap %}
   # Install Docker
@@ -41,6 +34,18 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io
   - systemctl start docker
   - systemctl enable docker
+  {% endif %}
+
+  {% if bootstrap and gpu_instance %}
+  # Install NVIDIA driver
+  - ubuntu-drivers install --gpgpu
+
+  # Install NVIDIA docker
+  - curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+  - curl -s -L https://nvidia.github.io/nvidia-docker/$(. /etc/os-release;echo $ID$VERSION_ID)/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+  - apt-get update -y
+  - apt-get install -y nvidia-docker2
+  - systemctl restart docker
   {% endif %}
 
   # Run container

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -1,6 +1,7 @@
 #cloud-config
 
 {% if bootstrap %}
+# Bootstrap
 packages:
   - apt-transport-https
   - ca-certificates

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -8,6 +8,7 @@ packages:
   - curl
   - gnupg-agent
   - software-properties-common
+  - ubuntu-drivers-common
 
 # Enable ipv4 forwarding, required on CIS hardened machines
 write_files:
@@ -38,7 +39,7 @@ runcmd:
 
   {% if bootstrap and gpu_instance %}
   # Install NVIDIA driver
-  - ubuntu-drivers install --gpgpu
+  - ubuntu-drivers install
 
   # Install NVIDIA docker
   - curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -


### PR DESCRIPTION
Due to a typo and missing attribute bootstrapping is being skipped on GCP. 

This appears to have been missed because the default GCP Ubuntu image comes with Docker pre installed.