### PR TITLE
Increase file descriptor limits on ECS/Fargate workers

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1105,6 +1105,13 @@ class ECSCluster(SpecCluster):
                             if not self._scheduler_extra_args
                             else self._scheduler_extra_args
                         ),
+                        "ulimits": [
+                            {
+                                "name": "nofile",
+                                "softLimit": 65535,
+                                "hardLimit": 65535,
+                            },
+                        ],
                         "logConfiguration": {
                             "logDriver": "awslogs",
                             "options": {
@@ -1171,6 +1178,13 @@ class ECSCluster(SpecCluster):
                             if not self._worker_extra_args
                             else self._worker_extra_args
                         ),
+                        "ulimits": [
+                            {
+                                "name": "nofile",
+                                "softLimit": 65535,
+                                "hardLimit": 65535,
+                            },
+                        ],
                         "logConfiguration": {
                             "logDriver": "awslogs",
                             "options": {


### PR DESCRIPTION
* This change resolves the issue of the maximum number of open file descriptors/network connections being exceeded at runtime. This is documented  in the Dask Distributed FAQs (https://distributed.dask.org/en/latest/faq.html). The issue occurs on `FargateCluster` nodes under some types of heavy workloads with large numbers of workers.
* The `nofile` hard and soft ulimits are set to `65535` (from default `1024`) in both the scheduler and worker nodes via the ECS task  definitions for each.
* Also see https://github.com/dask/distributed/issues/1858