### PR TITLE
Wrap googleapiclient compute in class to refresh expired tokens

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -550,12 +550,11 @@ class GCPCompute:
     """Wrapper for the ``googleapiclient`` compute object."""
 
     def __init__(self):
-        self._compute = None
-        self.refresh_client()
+        self._compute = self.refresh_client()
 
     def refresh_client(self):
         if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", False):
-            self._compute = googleapiclient.discovery.build("compute", "v1")
+            return googleapiclient.discovery.build("compute", "v1")
         else:
             import google.auth.credentials  # google-auth
 
@@ -571,15 +570,13 @@ class GCPCompute:
                     # take first row
                     f_.write(creds_rows[0][1])
                 creds, _ = google.auth.load_credentials_from_file(filename=f)
-            self._compute = googleapiclient.discovery.build(
-                "compute", "v1", credentials=creds
-            )
+            return googleapiclient.discovery.build("compute", "v1", credentials=creds)
 
     def instances(self):
         try:
             return self._compute.instances()
         except Exception:  # noqa
-            self.refresh_client()
+            self._compute = self.refresh_client()
             return self._compute.instances()
 
 

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -3,7 +3,7 @@ import pytest
 import dask
 from dask_cloudprovider.gcp.instances import (
     GCPCluster,
-    authenticate,
+    GCPCompute,
     GCPCredentialsError,
 )
 from dask.distributed import Client
@@ -12,7 +12,7 @@ from distributed.core import Status
 
 def skip_without_credentials():
     try:
-        authenticate()
+        _ = GCPCompute()
     except GCPCredentialsError:
         pytest.skip(
             """


### PR DESCRIPTION
Closes #179.

It looks like if you don't use a `googleapiclient` compute object for a while the tokens can expire.

This PR wraps the client in a class which will re-authenticate if an exception is raised. 