### PR TITLE
Reorder docstrings so that examples appear near the top

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -178,6 +178,23 @@ class EC2Cluster(VMCluster):
 
     See https://docs.dask.org/en/latest/configuration.html for more info.
 
+    Examples
+    --------
+
+    Regular cluster.
+
+    >>> cluster = EC2Cluster()
+    >>> cluster.scale(5)
+
+    RAPIDS Cluster.
+
+    >>> cluster = EC2Cluster(ami="ami-0c7c7d78f752f8f17",  # Example Deep Learning AMI (Ubuntu 18.04)
+                             docker_image="rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04",
+                             instance_type="p3.2xlarge",
+                             worker_module="dask_cuda.cli.dask_cuda_worker",
+                             bootstrap=False,
+                             filesystem_size=120)
+
     Parameters
     ----------
     region: string (optional)
@@ -287,22 +304,6 @@ class EC2Cluster(VMCluster):
             --query "Reservations[*].Instances[*].[InstanceId]" \\
             --output text | xargs aws ec2 terminate-instances --instance-ids
 
-    Examples
-    --------
-
-    Regular cluster.
-
-    >>> cluster = EC2Cluster()
-    >>> cluster.scale(5)
-
-    RAPIDS Cluster.
-
-    >>> cluster = EC2Cluster(ami="ami-0c7c7d78f752f8f17",  # Example Deep Learning AMI (Ubuntu 18.04)
-                             docker_image="rapidsai/rapidsai:cuda10.1-runtime-ubuntu18.04",
-                             instance_type="p3.2xlarge",
-                             worker_module="dask_cuda.cli.dask_cuda_worker",
-                             bootstrap=False,
-                             filesystem_size=120)
     """
 
     def __init__(

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -178,8 +178,7 @@ class EC2Cluster(VMCluster):
 
     See https://docs.dask.org/en/latest/configuration.html for more info.
 
-    Examples
-    --------
+    **Example usage**
 
     Regular cluster.
 

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -435,8 +435,7 @@ class ECSCluster(SpecCluster):
     All the other required resources such as roles, task definitions, tasks, etc
     will be created automatically like in :class:`FargateCluster`.
 
-    Examples
-    --------
+    **Example usage**
 
     >>> from dask_cloudprovider.aws import ECSCluster
     >>> cluster = ECSCluster(cluster_arn="arn:aws:ecs:<region>:<acctid>:cluster/<clustername>")

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -435,6 +435,28 @@ class ECSCluster(SpecCluster):
     All the other required resources such as roles, task definitions, tasks, etc
     will be created automatically like in :class:`FargateCluster`.
 
+    Examples
+    --------
+
+    >>> from dask_cloudprovider.aws import ECSCluster
+    >>> cluster = ECSCluster(cluster_arn="arn:aws:ecs:<region>:<acctid>:cluster/<clustername>")
+
+    There is also support in ``ECSCluster`` for GPU aware Dask clusters. To do
+    this you need to create an ECS cluster with GPU capable instances (from the
+    ``g3``, ``p3`` or ``p3dn`` families) and specify the number of GPUs each worker task
+    should have.
+
+    >>> from dask_cloudprovider.aws import ECSCluster
+    >>> cluster = ECSCluster(
+    ...     cluster_arn="arn:aws:ecs:<region>:<acctid>:cluster/<gpuclustername>",
+    ...     worker_gpu=1)
+
+    By setting the ``worker_gpu`` option to something other than ``None`` will cause the cluster
+    to run ``dask-cuda-worker`` as the worker startup command. Setting this option will also change
+    the default Docker image to ``rapidsai/rapidsai:latest``, if you're using a custom image
+    you must ensure the NVIDIA CUDA toolkit is installed with a version that matches the host machine
+    along with ``dask-cuda``.
+
     Parameters
     ----------
     fargate_scheduler: bool (optional)
@@ -617,28 +639,6 @@ class ECSCluster(SpecCluster):
         Default ``False``.
     **kwargs: dict
         Additional keyword arguments to pass to ``SpecCluster``.
-
-    Examples
-    --------
-
-    >>> from dask_cloudprovider.aws import ECSCluster
-    >>> cluster = ECSCluster(cluster_arn="arn:aws:ecs:<region>:<acctid>:cluster/<clustername>")
-
-    There is also support in ``ECSCluster`` for GPU aware Dask clusters. To do
-    this you need to create an ECS cluster with GPU capable instances (from the
-    ``g3``, ``p3`` or ``p3dn`` families) and specify the number of GPUs each worker task
-    should have.
-
-    >>> from dask_cloudprovider.aws import ECSCluster
-    >>> cluster = ECSCluster(
-    ...     cluster_arn="arn:aws:ecs:<region>:<acctid>:cluster/<gpuclustername>",
-    ...     worker_gpu=1)
-
-    By setting the ``worker_gpu`` option to something other than ``None`` will cause the cluster
-    to run ``dask-cuda-worker`` as the worker startup command. Setting this option will also change
-    the default Docker image to ``rapidsai/rapidsai:latest``, if you're using a custom image
-    you must ensure the NVIDIA CUDA toolkit is installed with a version that matches the host machine
-    along with ``dask-cuda``.
 
     .. _troubleshooting guide: ./troubleshooting.html#invalid-cpu-or-memory
     """
@@ -1238,11 +1238,6 @@ class FargateCluster(ECSCluster):
     If you do not configure a cluster one will be created for you with sensible
     defaults.
 
-    Parameters
-    ----------
-    kwargs: dict
-        Keyword arguments to be passed to :class:`ECSCluster`.
-
     Examples
     --------
 
@@ -1264,6 +1259,11 @@ class FargateCluster(ECSCluster):
     ``package-list.txt`` in your Dockerfile.  You could use the default
     `Dask Dockerfile <https://github.com/dask/dask-docker/blob/master/base/Dockerfile>`_ as a template and simply add
     your pinned additional packages.
+
+    Parameters
+    ----------
+    kwargs: dict
+        Keyword arguments to be passed to :class:`ECSCluster`.
 
     Notes
     -----

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -209,10 +209,7 @@ class AzureVMCluster(VMCluster):
 
     https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
-    Examples
-    --------
-
-    **Minimal example**
+    **Example usage**
 
     Create the cluster
 

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -209,70 +209,6 @@ class AzureVMCluster(VMCluster):
 
     https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
-    Parameters
-    ----------
-    location: str
-        The Azure location to launch you cluster in. List available locations with ``az account list-locations``.
-    resource_group: str
-        The resource group to create components in. List your resource groups with ``az group list``.
-    vnet: str
-        The vnet to attach VM network interfaces to. List your vnets with ``az network vnet list``.
-    security_group: str
-        The security group to apply to your VMs.
-        This must allow ports 8786-8787 from wherever you are running this from.
-        List your security greoups with ``az network nsg list``.
-    public_ingress: bool
-        Assign a public IP address to the scheduler. Default ``True``.
-    vm_size: str
-        Azure VM size to use for scheduler and workers. Default ``Standard_DS1_v2``.
-        List available VM sizes with ``az vm list-sizes --location <location>``.
-    vm_image: dict
-        By default all VMs will use the latest Ubuntu LTS release with the following configuration
-
-        ``{"publisher": "Canonical", "offer": "UbuntuServer","sku": "18.04-LTS", "version": "latest"}``
-
-        You can override any of these options by passing a dict with matching keys here.
-        For example if you wish to try Ubuntu 19.04 you can pass ``{"sku": "19.04"}`` and the ``publisher``,
-        ``offer`` and ``version`` will be used from the default.
-    bootstrap: bool (optional)
-        It is assumed that the ``VHD`` will not have Docker installed (or the NVIDIA drivers for GPU instances).
-        If ``bootstrap`` is ``True`` these dependencies will be installed on instance start. If you are using
-        a custom VHD which already has these dependencies set this to ``False.``
-    auto_shutdown: bool (optional)
-        Shutdown the VM if the Dask process exits. Default ``True``.
-    worker_module: str
-        The Dask worker module to start on worker VMs.
-    n_workers: int
-        Number of workers to initialise the cluster with. Defaults to ``0``.
-    worker_module: str
-        The Python module to run for the worker. Defaults to ``distributed.cli.dask_worker``
-    worker_options: dict
-        Params to be passed to the worker class.
-        See :class:`distributed.worker.Worker` for default worker class.
-        If you set ``worker_module`` then refer to the docstring for the custom worker class.
-    scheduler_options: dict
-        Params to be passed to the scheduler class.
-        See :class:`distributed.scheduler.Scheduler`.
-    docker_image: string (optional)
-        The Docker image to run on all instances.
-
-        This image must have a valid Python environment and have ``dask`` installed in order for the
-        ``dask-scheduler`` and ``dask-worker`` commands to be available. It is recommended the Python
-        environment matches your local environment where ``AzureVMCluster`` is being created from.
-
-        For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
-
-        By default the ``daskdev/dask:latest`` image will be used.
-    silence_logs: bool
-        Whether or not we should silence logging when setting up the cluster.
-    asynchronous: bool
-        If this is intended to be used directly within an event loop with
-        async/await
-    security : Security or bool, optional
-        Configures communication security in this cluster. Can be a security
-        object, or True. If True, temporary self-signed credentials will
-        be created automatically.
-
     Examples
     --------
 
@@ -380,6 +316,70 @@ class AzureVMCluster(VMCluster):
 
     >>> client.close()
     >>> cluster.close()
+
+    Parameters
+    ----------
+    location: str
+        The Azure location to launch you cluster in. List available locations with ``az account list-locations``.
+    resource_group: str
+        The resource group to create components in. List your resource groups with ``az group list``.
+    vnet: str
+        The vnet to attach VM network interfaces to. List your vnets with ``az network vnet list``.
+    security_group: str
+        The security group to apply to your VMs.
+        This must allow ports 8786-8787 from wherever you are running this from.
+        List your security greoups with ``az network nsg list``.
+    public_ingress: bool
+        Assign a public IP address to the scheduler. Default ``True``.
+    vm_size: str
+        Azure VM size to use for scheduler and workers. Default ``Standard_DS1_v2``.
+        List available VM sizes with ``az vm list-sizes --location <location>``.
+    vm_image: dict
+        By default all VMs will use the latest Ubuntu LTS release with the following configuration
+
+        ``{"publisher": "Canonical", "offer": "UbuntuServer","sku": "18.04-LTS", "version": "latest"}``
+
+        You can override any of these options by passing a dict with matching keys here.
+        For example if you wish to try Ubuntu 19.04 you can pass ``{"sku": "19.04"}`` and the ``publisher``,
+        ``offer`` and ``version`` will be used from the default.
+    bootstrap: bool (optional)
+        It is assumed that the ``VHD`` will not have Docker installed (or the NVIDIA drivers for GPU instances).
+        If ``bootstrap`` is ``True`` these dependencies will be installed on instance start. If you are using
+        a custom VHD which already has these dependencies set this to ``False.``
+    auto_shutdown: bool (optional)
+        Shutdown the VM if the Dask process exits. Default ``True``.
+    worker_module: str
+        The Dask worker module to start on worker VMs.
+    n_workers: int
+        Number of workers to initialise the cluster with. Defaults to ``0``.
+    worker_module: str
+        The Python module to run for the worker. Defaults to ``distributed.cli.dask_worker``
+    worker_options: dict
+        Params to be passed to the worker class.
+        See :class:`distributed.worker.Worker` for default worker class.
+        If you set ``worker_module`` then refer to the docstring for the custom worker class.
+    scheduler_options: dict
+        Params to be passed to the scheduler class.
+        See :class:`distributed.scheduler.Scheduler`.
+    docker_image: string (optional)
+        The Docker image to run on all instances.
+
+        This image must have a valid Python environment and have ``dask`` installed in order for the
+        ``dask-scheduler`` and ``dask-worker`` commands to be available. It is recommended the Python
+        environment matches your local environment where ``AzureVMCluster`` is being created from.
+
+        For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
+
+        By default the ``daskdev/dask:latest`` image will be used.
+    silence_logs: bool
+        Whether or not we should silence logging when setting up the cluster.
+    asynchronous: bool
+        If this is intended to be used directly within an event loop with
+        async/await
+    security : Security or bool, optional
+        Configures communication security in this cluster. Can be a security
+        object, or True. If True, temporary self-signed credentials will
+        be created automatically.
 
     """
 

--- a/dask_cloudprovider/azureml/azureml.py
+++ b/dask_cloudprovider/azureml/azureml.py
@@ -35,6 +35,73 @@ class AzureMLCluster(Cluster):
 
     This creates a dask scheduler and workers on an Azure ML Compute Target.
 
+    Examples
+    --------
+
+    First, import all necessary modules.
+
+    >>> from azureml.core import Workspace
+    >>> from dask_cloudprovider.azure import AzureMLCluster
+
+    Next, create the ``Workspace`` object given your AzureML ``Workspace`` parameters. Check
+    more in the AzureML documentation for
+    `Workspace <https://docs.microsoft.com/python/api/azureml-core/azureml.core.workspace.workspace?view=azure-ml-py>`_.
+
+    You can use ``ws = Workspace.from_config()`` after downloading the config file from the
+    `Azure Portal <https://portal.azure.com>`_ or `ML Studio <https://ml.azure.com>`_.
+
+    >>> subscription_id = "<your-subscription-id-here>"
+    >>> resource_group = "<your-resource-group>"
+    >>> workspace_name = "<your-workspace-name>"
+
+    >>> ws = Workspace(
+    ...     workspace_name=workspace_name,
+    ...     subscription_id=subscription_id,
+    ...     resource_group=resource_group
+    ... )
+
+    Then create the cluster.
+
+    >>> amlcluster = AzureMLCluster(
+    ...     # required
+    ...     ws,
+    ...     # optional
+    ...     vm_size="STANDARD_DS13_V2",                                 # Azure VM size for the Compute Target
+    ...     datastores=ws.datastores.values(),                          # Azure ML Datastores to mount on the headnode
+    ...     environment_definition=ws.environments['AzureML-Dask-CPU'], # Azure ML Environment to run on the cluster
+    ...     jupyter=true,                                               # Start JupyterLab session on the headnode
+    ...     initial_node_count=2,                                       # number of nodes to start
+    ...     scheduler_idle_timeout=7200                                 # scheduler idle timeout in seconds
+    ... )
+
+    Once the cluster has started, the Dask Cluster widget will print out two links:
+
+    1. Jupyter link to a Jupyter Lab instance running on the headnode.
+    2. Dask Dashboard link.
+
+    Note that ``AzureMLCluster`` uses IPython Widgets to present this information, so if you are working in Jupyter Lab
+    and see text that starts with ``VBox(children=``..., make sure you have enabled the IPython Widget
+    `extension <https://jupyterlab.readthedocs.io/en/stable/user/extensions.html>`_.
+
+    To connect to the Jupyter Lab session running on the cluster from your own computer, click the link provided in the
+    widget printed above, or if you need the link directly it is stored in ``amlcluster.jupyter_link``.
+
+    Once connected, you'll be in an AzureML `Run` session. To connect Dask from within the session, just run to
+    following code to connect dask to the cluster:
+
+    .. code-block:: python
+
+        from azureml.core import Run
+        from dask.distributed import Client
+
+        run = Run.get_context()
+        c = Client(run.get_metrics()["scheduler"])
+
+
+    You can stop the cluster with `amlcluster.close()`. The cluster will automatically spin down if unused for
+    20 minutes by default. Alternatively, you can delete the Azure ML Compute Target or cancel the Run from the
+    Python SDK or UI to stop the cluster.
+
     Parameters
     ----------
     workspace: azureml.core.Workspace (required)
@@ -145,74 +212,6 @@ class AzureMLCluster(Cluster):
 
     **kwargs: dict
         Additional keyword arguments.
-
-    Examples
-    --------
-
-    First, import all necessary modules.
-
-    >>> from azureml.core import Workspace
-    >>> from dask_cloudprovider.azure import AzureMLCluster
-
-    Next, create the ``Workspace`` object given your AzureML ``Workspace`` parameters. Check
-    more in the AzureML documentation for
-    `Workspace <https://docs.microsoft.com/python/api/azureml-core/azureml.core.workspace.workspace?view=azure-ml-py>`_.
-
-    You can use ``ws = Workspace.from_config()`` after downloading the config file from the
-    `Azure Portal <https://portal.azure.com>`_ or `ML Studio <https://ml.azure.com>`_.
-
-    >>> subscription_id = "<your-subscription-id-here>"
-    >>> resource_group = "<your-resource-group>"
-    >>> workspace_name = "<your-workspace-name>"
-
-    >>> ws = Workspace(
-    ...     workspace_name=workspace_name,
-    ...     subscription_id=subscription_id,
-    ...     resource_group=resource_group
-    ... )
-
-    Then create the cluster.
-
-    >>> amlcluster = AzureMLCluster(
-    ...     # required
-    ...     ws,
-    ...     # optional
-    ...     vm_size="STANDARD_DS13_V2",                                 # Azure VM size for the Compute Target
-    ...     datastores=ws.datastores.values(),                          # Azure ML Datastores to mount on the headnode
-    ...     environment_definition=ws.environments['AzureML-Dask-CPU'], # Azure ML Environment to run on the cluster
-    ...     jupyter=true,                                               # Start JupyterLab session on the headnode
-    ...     initial_node_count=2,                                       # number of nodes to start
-    ...     scheduler_idle_timeout=7200                                 # scheduler idle timeout in seconds
-    ... )
-
-    Once the cluster has started, the Dask Cluster widget will print out two links:
-
-    1. Jupyter link to a Jupyter Lab instance running on the headnode.
-    2. Dask Dashboard link.
-
-    Note that ``AzureMLCluster`` uses IPython Widgets to present this information, so if you are working in Jupyter Lab
-    and see text that starts with ``VBox(children=``..., make sure you have enabled the IPython Widget
-    `extension <https://jupyterlab.readthedocs.io/en/stable/user/extensions.html>`_.
-
-    To connect to the Jupyter Lab session running on the cluster from your own computer, click the link provided in the
-    widget printed above, or if you need the link directly it is stored in ``amlcluster.jupyter_link``.
-
-    Once connected, you'll be in an AzureML `Run` session. To connect Dask from within the session, just run to
-    following code to connect dask to the cluster:
-
-    .. code-block:: python
-
-        from azureml.core import Run
-        from dask.distributed import Client
-
-        run = Run.get_context()
-        c = Client(run.get_metrics()["scheduler"])
-
-
-    You can stop the cluster with `amlcluster.close()`. The cluster will automatically spin down if unused for
-    20 minutes by default. Alternatively, you can delete the Azure ML Compute Target or cancel the Run from the
-    Python SDK or UI to stop the cluster.
-
 
     """
 

--- a/dask_cloudprovider/azureml/azureml.py
+++ b/dask_cloudprovider/azureml/azureml.py
@@ -35,8 +35,7 @@ class AzureMLCluster(Cluster):
 
     This creates a dask scheduler and workers on an Azure ML Compute Target.
 
-    Examples
-    --------
+    **Example usage**
 
     First, import all necessary modules.
 

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -97,51 +97,6 @@ class DropletCluster(VMCluster):
 
     https://www.digitalocean.com/docs/apis-clis/doctl/how-to/install/
 
-    Parameters
-    ----------
-    region: str
-        The DO region to launch you cluster in. A full list can be obtained with ``doctl compute region list``.
-    size: str
-        The VM size slug. You can get a full list with ``doctl compute size list``.
-        The default is ``s-1vcpu-1gb`` which is 1GB RAM and 1 vCPU
-    image: str
-        The image ID to use for the host OS. This should be a Ubuntu variant.
-        You can list available images with ``doctl compute image list --public | grep ubuntu.*x64``.
-    worker_module: str
-        The Dask worker module to start on worker VMs.
-    n_workers: int
-        Number of workers to initialise the cluster with. Defaults to ``0``.
-    worker_module: str
-        The Python module to run for the worker. Defaults to ``distributed.cli.dask_worker``
-    worker_options: dict
-        Params to be passed to the worker class.
-        See :class:`distributed.worker.Worker` for default worker class.
-        If you set ``worker_module`` then refer to the docstring for the custom worker class.
-    scheduler_options: dict
-        Params to be passed to the scheduler class.
-        See :class:`distributed.scheduler.Scheduler`.
-    docker_image: string (optional)
-        The Docker image to run on all instances.
-
-        This image must have a valid Python environment and have ``dask`` installed in order for the
-        ``dask-scheduler`` and ``dask-worker`` commands to be available. It is recommended the Python
-        environment matches your local environment where ``EC2Cluster`` is being created from.
-
-        For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
-
-        By default the ``daskdev/dask:latest`` image will be used.
-    env_vars: dict (optional)
-        Environment variables to be passed to the worker.
-    silence_logs: bool
-        Whether or not we should silence logging when setting up the cluster.
-    asynchronous: bool
-        If this is intended to be used directly within an event loop with
-        async/await
-    security : Security or bool, optional
-        Configures communication security in this cluster. Can be a security
-        object, or True. If True, temporary self-signed credentials will
-        be created automatically.
-
     Examples
     --------
 
@@ -190,6 +145,51 @@ class DropletCluster(VMCluster):
     0.5000558682356162
     Terminated droplet dask-48efe585-worker-5181aaf1
     Terminated droplet dask-48efe585-scheduler
+
+    Parameters
+    ----------
+    region: str
+        The DO region to launch you cluster in. A full list can be obtained with ``doctl compute region list``.
+    size: str
+        The VM size slug. You can get a full list with ``doctl compute size list``.
+        The default is ``s-1vcpu-1gb`` which is 1GB RAM and 1 vCPU
+    image: str
+        The image ID to use for the host OS. This should be a Ubuntu variant.
+        You can list available images with ``doctl compute image list --public | grep ubuntu.*x64``.
+    worker_module: str
+        The Dask worker module to start on worker VMs.
+    n_workers: int
+        Number of workers to initialise the cluster with. Defaults to ``0``.
+    worker_module: str
+        The Python module to run for the worker. Defaults to ``distributed.cli.dask_worker``
+    worker_options: dict
+        Params to be passed to the worker class.
+        See :class:`distributed.worker.Worker` for default worker class.
+        If you set ``worker_module`` then refer to the docstring for the custom worker class.
+    scheduler_options: dict
+        Params to be passed to the scheduler class.
+        See :class:`distributed.scheduler.Scheduler`.
+    docker_image: string (optional)
+        The Docker image to run on all instances.
+
+        This image must have a valid Python environment and have ``dask`` installed in order for the
+        ``dask-scheduler`` and ``dask-worker`` commands to be available. It is recommended the Python
+        environment matches your local environment where ``EC2Cluster`` is being created from.
+
+        For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
+
+        By default the ``daskdev/dask:latest`` image will be used.
+    env_vars: dict (optional)
+        Environment variables to be passed to the worker.
+    silence_logs: bool
+        Whether or not we should silence logging when setting up the cluster.
+    asynchronous: bool
+        If this is intended to be used directly within an event loop with
+        async/await
+    security : Security or bool, optional
+        Configures communication security in this cluster. Can be a security
+        object, or True. If True, temporary self-signed credentials will
+        be created automatically.
 
     """
 

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -97,8 +97,7 @@ class DropletCluster(VMCluster):
 
     https://www.digitalocean.com/docs/apis-clis/doctl/how-to/install/
 
-    Examples
-    --------
+    **Example usage**
 
     Create the cluster.
 

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -353,6 +353,76 @@ class GCPCluster(VMCluster):
 
     https://cloud.google.com/sdk/gcloud
 
+    Examples
+    --------
+
+    Create the cluster.
+
+    >>> from dask_cloudprovider.gcp import GCPCluster
+    >>> cluster = GCPCluster(n_workers=1)
+    Launching cluster with the following configuration:
+    Source Image: projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20201014
+    Docker Image: daskdev/dask:latest
+    Machine Type: n1-standard-1
+    Filesytsem Size: 50
+    N-GPU Type:
+    Zone: us-east1-c
+    Creating scheduler instance
+    dask-acc897b9-scheduler
+            Internal IP: 10.142.0.37
+            External IP: 34.75.60.62
+    Waiting for scheduler to run
+    Scheduler is running
+    Creating worker instance
+    dask-acc897b9-worker-bfbc94bc
+            Internal IP: 10.142.0.39
+            External IP: 34.73.245.220
+
+    Connect a client.
+
+    >>> from dask.distributed import Client
+    >>> client = Client(cluster)
+
+    Do some work.
+
+    >>> import dask.array as da
+    >>> arr = da.random.random((1000, 1000), chunks=(100, 100))
+    >>> arr.mean().compute()
+    0.5001550986751964
+
+    Close the cluster
+
+    >>> cluster.close()
+    Closing Instance: dask-acc897b9-worker-bfbc94bc
+    Closing Instance: dask-acc897b9-scheduler
+
+    You can also do this all in one go with context managers to ensure the cluster is
+    created and cleaned up.
+
+    >>> with GCPCluster(n_workers=1) as cluster:
+    ...     with Client(cluster) as client:
+    ...         print(da.random.random((1000, 1000), chunks=(100, 100)).mean().compute())
+    Launching cluster with the following configuration:
+    Source Image: projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20201014
+    Docker Image: daskdev/dask:latest
+    Machine Type: n1-standard-1
+    Filesytsem Size: 50
+    N-GPU Type:
+    Zone: us-east1-c
+    Creating scheduler instance
+    dask-19352f29-scheduler
+            Internal IP: 10.142.0.41
+            External IP: 34.73.217.251
+    Waiting for scheduler to run
+    Scheduler is running
+    Creating worker instance
+    dask-19352f29-worker-91a6bfe0
+            Internal IP: 10.142.0.48
+            External IP: 34.73.245.220
+    0.5000812282861661
+    Closing Instance: dask-19352f29-worker-91a6bfe0
+    Closing Instance: dask-19352f29-scheduler
+
     Parameters
     ----------
     projectid: str
@@ -423,76 +493,6 @@ class GCPCluster(VMCluster):
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically.
-
-    Examples
-    --------
-
-    Create the cluster.
-
-    >>> from dask_cloudprovider.gcp import GCPCluster
-    >>> cluster = GCPCluster(n_workers=1)
-    Launching cluster with the following configuration:
-    Source Image: projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20201014
-    Docker Image: daskdev/dask:latest
-    Machine Type: n1-standard-1
-    Filesytsem Size: 50
-    N-GPU Type:
-    Zone: us-east1-c
-    Creating scheduler instance
-    dask-acc897b9-scheduler
-            Internal IP: 10.142.0.37
-            External IP: 34.75.60.62
-    Waiting for scheduler to run
-    Scheduler is running
-    Creating worker instance
-    dask-acc897b9-worker-bfbc94bc
-            Internal IP: 10.142.0.39
-            External IP: 34.73.245.220
-
-    Connect a client.
-
-    >>> from dask.distributed import Client
-    >>> client = Client(cluster)
-
-    Do some work.
-
-    >>> import dask.array as da
-    >>> arr = da.random.random((1000, 1000), chunks=(100, 100))
-    >>> arr.mean().compute()
-    0.5001550986751964
-
-    Close the cluster
-
-    >>> cluster.close()
-    Closing Instance: dask-acc897b9-worker-bfbc94bc
-    Closing Instance: dask-acc897b9-scheduler
-
-    You can also do this all in one go with context managers to ensure the cluster is
-    created and cleaned up.
-
-    >>> with GCPCluster(n_workers=1) as cluster:
-    ...     with Client(cluster) as client:
-    ...         print(da.random.random((1000, 1000), chunks=(100, 100)).mean().compute())
-    Launching cluster with the following configuration:
-    Source Image: projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20201014
-    Docker Image: daskdev/dask:latest
-    Machine Type: n1-standard-1
-    Filesytsem Size: 50
-    N-GPU Type:
-    Zone: us-east1-c
-    Creating scheduler instance
-    dask-19352f29-scheduler
-            Internal IP: 10.142.0.41
-            External IP: 34.73.217.251
-    Waiting for scheduler to run
-    Scheduler is running
-    Creating worker instance
-    dask-19352f29-worker-91a6bfe0
-            Internal IP: 10.142.0.48
-            External IP: 34.73.245.220
-    0.5000812282861661
-    Closing Instance: dask-19352f29-worker-91a6bfe0
-    Closing Instance: dask-19352f29-scheduler
 
     """
 

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -353,8 +353,7 @@ class GCPCluster(VMCluster):
 
     https://cloud.google.com/sdk/gcloud
 
-    Examples
-    --------
+    **Example usage**
 
     Create the cluster.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,6 +91,8 @@ pygments_style = "default"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Order autodoc sections by the order they appear in the docstring
+autodoc_member_order = "bysource"
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
Many cluster managers have a large number of parameters and with the default autodoc ordering the examples section can get buried at the bottom.

This PR changes sphinx to preserve the ordering from the docstring and moves the examples section near the top.

I am very keen that Dask Cloudprovider has example-driven documentation. So we should work to make examples plentiful and easy to find.