### PR TITLE
Fix import error messages

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -20,8 +20,8 @@ except ImportError as e:
     msg = (
         "Dask Cloud Provider AWS requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
-        "  conda install dask-cloudprovider                           # either conda install\n"
-        '  python -m pip install "dask-cloudprovider[aws]" --upgrade  # or python -m pip install'
+        "  conda install -c conda-forge dask-cloudprovider       # either conda install\n"
+        '  pip install "dask-cloudprovider[aws]" --upgrade       # or python -m pip install'
     )
     raise ImportError(msg) from e
 

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -28,8 +28,8 @@ except ImportError as e:
     msg = (
         "Dask Cloud Provider AWS requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
-        "  conda install dask-cloudprovider                           # either conda install\n"
-        '  python -m pip install "dask-cloudprovider[aws]" --upgrade  # or python -m pip install'
+        "  conda install -c conda-forge dask-cloudprovider       # either conda install\n"
+        '  pip install "dask-cloudprovider[aws]" --upgrade       # or python -m pip install'
     )
     raise ImportError(msg) from e
 

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -18,8 +18,8 @@ except ImportError as e:
     msg = (
         "Dask Cloud Provider Azure requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
-        "  conda install dask-cloudprovider                             # either conda install\n"
-        '  python -m pip install "dask-cloudprovider[azure]" --upgrade  # or python -m pip install'
+        "  conda install -c conda-forge dask-cloudprovider       # either conda install\n"
+        '  pip install "dask-cloudprovider[azure]" --upgrade       # or python -m pip install'
     )
     raise ImportError(msg) from e
 

--- a/dask_cloudprovider/azureml/azureml.py
+++ b/dask_cloudprovider/azureml/azureml.py
@@ -22,7 +22,7 @@ except ImportError as e:
     msg = (
         "Dask Cloud Provider Azure ML requirements are not installed.\n\n"
         "Please either pip install as follows:\n\n"
-        '  python -m pip install "dask-cloudprovider[azureml]" --upgrade  # or python -m pip install'
+        '  pip install "dask-cloudprovider[azureml]" --upgrade  # or python -m pip install'
     )
     raise ImportError(msg) from e
 

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -13,9 +13,8 @@ try:
 except ImportError as e:
     msg = (
         "Dask Cloud Provider Digital Ocean requirements are not installed.\n\n"
-        "Please either conda or pip install as follows:\n\n"
-        "  conda install dask-cloudprovider                           # either conda install\n"
-        '  python -m pip install "dask-cloudprovider[digitalocean]" --upgrade  # or python -m pip install'
+        "Please pip install as follows:\n\n"
+        '  pip install "dask-cloudprovider[digitalocean]" --upgrade  # or python -m pip install'
     )
     raise ImportError(msg) from e
 

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -23,8 +23,8 @@ except ImportError as e:
     msg = (
         "Dask Cloud Provider GCP requirements are not installed.\n\n"
         "Please either conda or pip install as follows:\n\n"
-        "  conda install -c conda-forge google-api-python-client google-auth # either conda install\n"
-        '  python -m pip install "dask-cloudprovider[gcp]" --upgrade  # or python -m pip install'
+        "  conda install -c conda-forge dask-cloudprovider       # either conda install\n"
+        '  pip install "dask-cloudprovider[gcp]" --upgrade       # or python -m pip install'
     )
     raise ImportError(msg) from e
 


### PR DESCRIPTION
Updated import error messages to be consistent and reflect the current packaging state:

- All conda commands now have `-c conda-forge` argument.
- Simplified `python -m pip` command because it is mentioned in a comment already.
- AzureML and DigitalOcean packages are not currently on confa-forge and it's not our place to take on that maintenance. So simplified the error message to only mention pip.
- Google cloud conda error now says to install `dask-cloudprovider` instead of the specific dependencies (relies on  conda-forge/dask-cloudprovider-feedstock#9)