### PR TITLE
Install Dask from conda-forge before doing a dev install

### DIFF
--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -6,6 +6,8 @@ dependencies:
   - python=3.7
   - nomkl
   - pip
+  # Dask
+  - dask
   # testing / CI
   - flake8
   - ipywidgets

--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -6,8 +6,6 @@ dependencies:
   - python=3.7
   - nomkl
   - pip
-  # Dask
-  - dask
   # testing / CI
   - flake8
   - ipywidgets
@@ -34,5 +32,5 @@ dependencies:
   - pytest-asyncio >=0.14.0
   - pytest-timeout
   - pip:
-      - git+https://github.com/dask/dask
-      - git+https://github.com/dask/distributed
+      - git+https://github.com/dask/dask.git@master
+      - git+https://github.com/dask/distributed@master

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -6,6 +6,8 @@ dependencies:
   - python=3.8
   - nomkl
   - pip
+  # Dask
+  - dask
   # testing / CI
   - flake8
   - ipywidgets

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -34,5 +34,5 @@ dependencies:
   - pytest-asyncio >=0.14.0
   - pytest-timeout
   - pip:
-      - git+https://github.com/dask/dask
-      - git+https://github.com/dask/distributed
+      - git+https://github.com/dask/dask.git@master
+      - git+https://github.com/dask/distributed@master


### PR DESCRIPTION
Pip seems to be failing to install Dask and Distributed from master in recent CI runs.

Attempting to install Dask from exactly the same URL as distributed does make dependency resolution easier.