### PR TITLE
Build distribution and publish to PyPI on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.7
 
       - name: Install pypa/build
-        run: python -m pip install build
+        run: python -m pip install build wheel
 
       - name: Build distributions
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build distribution
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install pypa/build
+        run: pytnon -m pip install build
+
+      - name: Build distributions
+        shell: bash -l {0}
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish package to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.7
 
       - name: Install pypa/build
-        run: pytnon -m pip install build
+        run: python -m pip install build
 
       - name: Build distributions
         shell: bash -l {0}

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,13 @@ Dask Cloud Provider
    :target: https://github.com/dask/dask-cloudprovider/actions?query=workflow%3ACI
    :alt: Build Status
 
-.. image:: https://img.shields.io/readthedocs/dask-cloudprovider
+.. image:: https://img.shields.io/readthedocs/dask-cloudprovider?color=%232980B9&logo=read-the-docs&logoColor=white
    :target: https://cloudprovider.dask.org/
    :alt: Read the Docs
+
+.. image:: https://img.shields.io/readthedocs/dask-cloudprovider?color=%232980B9&label=developer%20docs&logo=read-the-docs&logoColor=white
+   :target: https://cloudprovider.dask.org/
+   :alt: Read the Docs Developer
 
 
 Native Cloud integration for Dask. This library intends to allow people to

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Dask Cloud Provider
    :alt: Read the Docs
 
 .. image:: https://img.shields.io/readthedocs/dask-cloudprovider?color=%232980B9&label=developer%20docs&logo=read-the-docs&logoColor=white
-   :target: https://cloudprovider.dask.org/
+   :target: https://cloudprovider.dask.org/releasing.html
    :alt: Read the Docs Developer
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -77,3 +77,10 @@ this code.
     troubleshooting.rst
     gpus.rst
     packer.rst
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+    :caption: Developer
+
+    releasing.rst

--- a/doc/source/releasing.rst
+++ b/doc/source/releasing.rst
@@ -1,0 +1,10 @@
+Releasing
+=========
+
+Releases are published automatically when a tag is pushed to GitHub.
+
+.. code-block:: bash
+
+    git commit --allow-empty -m "Release x.x.x"
+    git tag -a x.x.x -m 'Version x.x.x'
+    git push upstream --tags


### PR DESCRIPTION
This PR adds a GitHub Actions workflow which will attempt to build a package distribution for dask-cloudprovider.

It will also upload that package to PyPI if run on a tagged branch in dask/dask-cloudprovider.