### PR TITLE
No publish forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish package to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'dask/dask-cloudprovider' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
Pushing tags to forks will currently trigger a release, which will fail due to a missing secret.

This PR updates the if to avoid this.