### PR TITLE
Expose SSH key and Instance IAM Role config options in EC2Cluster

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -338,6 +338,18 @@ class EC2Cluster(VMCluster):
                              worker_module="dask_cuda.cli.dask_cuda_worker",
                              bootstrap=False,
                              filesystem_size=120)
+
+    Enable SSH for debugging
+
+    >>> from dask_cloudprovider.aws import EC2Cluster
+    >>> cluster = EC2Cluster(key_name="myawesomekey",
+                             # Security group which allows ports 22, 8786, 8787 and all internal traffic
+                             security_groups=["sg-aabbcc112233"])
+
+    # You can now SSH to an instance with `ssh ubuntu@public_ip`
+
+    >>> cluster.close()
+
     """
 
     def __init__(

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -46,6 +46,10 @@ cloudprovider:
     # subnet_id: "" # Subnet ID for instances to. Defaults to all subnets in default VPC.
     # security_groups: [] # Security groups for instances. Will create a minimal Dask security group by default.
     filesystem_size: 40 # Default root filesystem size for scheduler and worker VMs in GB
+    key_name: null # SSH Key name to assign to instances
+    iam_instance_profile: {} # Iam role to assign to instances
+      # Arn: 'string'
+      # Name: 'string'
 
   azure:
     location: null # The Azure location to launch your cluster

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+pytest-timeout

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,2 @@
 pytest
 pytest-asyncio
-pytest-timeout


### PR DESCRIPTION
This PR adds two new config/keyword argument options to `EC2Cluster`.

**key_name**

With `key_name` you can assign an existing key pair to all instances in your cluster. This is useful to enable debugging via SSH.

*Note that you will need to ensure you choose a security group which allows port 22*.

```console
$ aws ec2 describe-key-pairs  --query 'KeyPairs[*].KeyName' --output text
myawesomekey
```

```python
from dask_cloudprovider.aws import EC2Cluster

cluster = EC2Cluster(
    key_name="myawesomekey",
    security_groups=["sg-aabbcc112233"]  # Security group which allows ports 22, 8786, 8787 and all internal traffic
)

# You can now SSH to an instance with `ssh ubuntu@public_ip`

cluster.close()
```

**iam_instance_profile**

The `iam_instance_profile` enables you to assign an IAM Role to all instances created.

A common use case would be to create an EC2 role with the `AmazonS3ReadOnlyAccess` policy and then attach it to instances in your Dask cluster.

```python
from dask_cloudprovider.aws import EC2Cluster

cluster = EC2Cluster(
   iam_instance_profile={"Name": "myrole"}
)

# All instances will now have the IAM role `myrole` and all permissions associated with it.

cluster.close()
```
