### PR TITLE
Add config option to specify availibility zone

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 
 import dask
 from dask_cloudprovider.generic.vmcluster import (
@@ -137,6 +138,8 @@ class EC2Instance(VMInterface):
                 vm_kwargs["IamInstanceProfile"] = self.iam_instance_profile
 
             if self.availability_zone:
+                if isinstance(self.availability_zone, list):
+                    self.availability_zone = random.choice(self.availability_zone)
                 vm_kwargs["Placement"] = {"AvailabilityZone": self.availability_zone}
 
             response = await client.run_instances(**vm_kwargs)
@@ -212,8 +215,10 @@ class EC2Cluster(VMCluster):
     ----------
     region: string (optional)
         The region to start you clusters. By default this will be detected from your config.
-    availability_zone: string (optional)
+    availability_zone: string or List(string) (optional)
         The availability zone to start you clusters. By default AWS will select the AZ with most free capacity.
+        If you specify more than one then scheduler and worker VMs will be randomly assigned to one of your
+        chosen AZs.
     bootstrap: bool (optional)
         It is assumed that the ``ami`` will not have Docker installed (or the NVIDIA drivers for GPU instances).
         If ``bootstrap`` is ``True`` these dependencies will be installed on instance start. If you are using

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -36,6 +36,7 @@ cloudprovider:
 
   ec2:
     region: null # AWS region to create cluster. Defaults to environment or account default region.
+    availability_zone: null # The availability zone to start you clusters. By default AWS will select the AZ with most free capacity.
     bootstrap: true # It is assumed that the AMI does not have Docker and needs bootstrapping. Set this to false if using a custom AMI with Docker already installed.
     auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.
     # worker_command: "dask-worker" # The command for workers to run. If the instance_type is a GPU instance dask-cuda-worker will be used.


### PR DESCRIPTION
There are situations where you may want to specify which availability zone to use. This PR adds a config option to enable this.

**Specify single AZ**

```python
cluster = EC2Cluster(region="us-east-1", availability_zone="us-east-1a")
```

**Specify multiple AZs**

Scheduler and worker VMs will be randomly assigned.

```python
cluster = EC2Cluster(region="us-east-1", availability_zone=["us-east-1a", "us-east-1b"])
```