### PR TITLE
Implement security option in VM cluster managers

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -301,7 +301,7 @@ class EC2Cluster(VMCluster):
     security : Security or bool, optional
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
-        be created automatically.
+        be created automatically. Default is ``True``.
 
     Notes
     -----

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -273,7 +273,7 @@ class AzureVMCluster(VMCluster):
     security : Security or bool, optional
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
-        be created automatically.
+        be created automatically. Default is ``True``.
 
     Examples
     --------

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -139,7 +139,7 @@ class DropletCluster(VMCluster):
     security : Security or bool, optional
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
-        be created automatically.
+        be created automatically. Default is ``True``.
 
     Examples
     --------

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -424,7 +424,7 @@ class GCPCluster(VMCluster):
     security : Security or bool (optional)
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
-        be created automatically.
+        be created automatically. Default is ``True``.
 
     Examples
     --------

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -280,10 +280,10 @@ class GCPScheduler(SchedulerMixin, GCPInstance):
 
         if self.config.get("public_ingress", True):
             # scheduler is publicly available
-            self.address = f"tcp://{self.external_ip}:8786"
+            self.address = f"{self.cluster.protocol}://{self.external_ip}:8786"
         else:
             # scheduler is only accessible within VPC
-            self.address = f"tcp://{self.internal_ip}:8786"
+            self.address = f"{self.cluster.protocol}://{self.internal_ip}:8786"
         await self.wait_for_scheduler()
 
         # need to reserve internal IP for workers
@@ -307,7 +307,9 @@ class GCPWorker(GCPInstance):
         self.scheduler = scheduler
         self.worker_class = worker_class
         self.name = f"dask-{self.cluster.uuid}-worker-{str(uuid.uuid4())[:8]}"
-        internal_scheduler = f"{self.cluster.scheduler_internal_ip}:8786"
+        internal_scheduler = (
+            f"{self.cluster.protocol}://{self.cluster.scheduler_internal_ip}:8786"
+        )
         self.command = " ".join(
             [
                 self.set_env,

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -57,7 +57,7 @@ async def test_init():
 async def test_get_cloud_init():
     skip_without_credentials()
 
-    cloud_init = GCPCluster.get_cloud_init()
+    cloud_init = GCPCluster.get_cloud_init(security=True)
     assert "dask-scheduler" in cloud_init
     assert "# Bootstrap" in cloud_init
 
@@ -67,7 +67,9 @@ async def test_get_cloud_init():
 async def test_create_cluster():
     skip_without_credentials()
 
-    async with GCPCluster(asynchronous=True, env_vars={"FOO": "bar"}) as cluster:
+    async with GCPCluster(
+        asynchronous=True, env_vars={"FOO": "bar"}, security=True
+    ) as cluster:
 
         assert cluster.status == Status.running
 

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -194,7 +194,7 @@ class VMCluster(SpecCluster):
     security : Security or bool, optional
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
-        be created automatically.
+        be created automatically. Default is ``True``.
 
     """
 

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -216,7 +216,7 @@ class VMCluster(SpecCluster):
         scheduler_options: dict = {},
         docker_image="daskdev/dask:latest",
         env_vars: dict = {},
-        security: bool = None,
+        security: bool = True,
         protocol: str = None,
         **kwargs,
     ):
@@ -226,7 +226,7 @@ class VMCluster(SpecCluster):
             )
         self._n_workers = n_workers
 
-        if security is None:
+        if not security:
             # Falsey values load the default configuration
             self.security = Security()
         elif security is True:

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -227,8 +227,7 @@ class VMCluster(SpecCluster):
         self._n_workers = n_workers
 
         if not security:
-            # Falsey values load the default configuration
-            self.security = Security()
+            self.security = None
         elif security is True:
             # True indicates self-signed temporary credentials should be used
             self.security = Security.temporary()

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -192,4 +192,8 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "dask": ("https://docs.dask.org/en/latest/", None),
+    "distributed": ("https://distributed.dask.org/en/latest/", None),
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,7 +191,6 @@ texinfo_documents = [
 ]
 
 
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "dask": ("https://docs.dask.org/en/latest/", None),

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -75,6 +75,7 @@ this code.
     :caption: Advanced
 
     troubleshooting.rst
+    security.rst
     gpus.rst
     packer.rst
 

--- a/doc/source/security.rst
+++ b/doc/source/security.rst
@@ -27,7 +27,7 @@ When a cluster is launched with any of these cluster managers a set of temporary
 via their startup script. All communication between the client, scheduler and workers will then be encrypted and only clients and workers with
 valid certificates will be able to connect to the scheduler.
 
-You can also specify your own certificates using the :class:`distributed.Security` object.
+You can also specify your own certificates using the :class:`distributed.security.Security` object.
 
 .. code-block:: python
 

--- a/doc/source/security.rst
+++ b/doc/source/security.rst
@@ -1,0 +1,47 @@
+Security
+========
+
+Dask Cloudprovider aims to balance ease of use with security best practices. The two are not always compatible so this document aims to outline the compromises and decisions made in this library.
+
+Public Schedulers
+-----------------
+
+For each cluster manager to work correctly it must be able to make a connection to the Dask scheduler on port ``8786``.
+In many cluster managers the default option is to expose the Dask scheduler and dashboard to the internet via a public IP address.
+This makes things quick and easy for new users to get up and running, but may pose a security risk long term.
+
+Many organisations have policies which do not allow users to assign public IP addresses or open ports. Our best practices
+advice is to use Dask Cloudprovider from within a cloud platform, either from a VM or a managed environment. Then disable public
+networking.
+
+See each cluster manager for configuration options.
+
+Authentication and encryption
+-----------------------------
+
+Cluster managers such as :class:`dask_cloudprovider.aws.EC2Cluster`, :class:`dask_cloudprovider.azure.AzureVMCluster`,
+:class:`dask_cloudprovider.gcp.GCPCluster` and :class:`dask_cloudprovider.digitalocean.DropletCluster` enable certificate based authentication
+and encryption by default.
+
+When a cluster is launched with any of these cluster managers a set of temporary keys will be generated and distributed to the cluster nodes
+via their startup script. All communication between the client, scheduler and workers will then be encrypted and only clients and workers with
+valid certificates will be able to connect to the scheduler.
+
+You can also specify your own certificates using the :class:`distributed.Security` object.
+
+.. code-block:: python
+
+    >>> from dask_cloudprovider.gcp import GCPCluster
+    >>> from dask.distributed import Client
+    >>> from distributed.security import Security
+    >>> sec = Security(tls_ca_file='cluster_ca.pem',
+    ...                tls_client_cert='cli_cert.pem',
+    ...                tls_client_key='cli_key.pem',
+    ...                require_encryption=True)
+    >>> cluster = GCPCluster(n_workers=1, security=sec)
+    >>> client = Client(cluster)
+    >>> client
+    <Client: 'tls://10.142.0.29:8786' processes=0 threads=0, memory=0 B>
+
+You can disable secure connections by setting the ``security`` keyword argument to ``False``. This may be desirable when troubleshooting or
+when running on a trusted network (entirely inside a VPC for example).


### PR DESCRIPTION
This PR implements the `security` keyword argument for `VMCluster` based cluster managers.

This depends on dask/distributed#4364 as credentials are distributed via the Dask config and it seems there are a couple of bugs in the way this works.

### Examples

#### Temporary credentials

Setting `security=True` will generate temporary credentials which will be distributed to the scheduler and workers at creation time. This is also the new default option.

```python
>>> from dask_cloudprovider.gcp import GCPCluster
>>> from dask.distributed import Client
>>> cluster = GCPCluster(n_workers=1, security=True)
>>> client = Client(cluster)
>>> client
<Client: 'tls://10.142.0.29:8786' processes=0 threads=0, memory=0 B>
```

Note the TLS here in the connection URL. Only clients with the credentials will be able to connect. In this example the `Client` class retrieves the credentials from the `cluster` object.

#### Custom certificates

You can also set `security` to a [custom `Security` object](https://distributed.dask.org/en/latest/tls.html#distributed.security.Security) with your own generated certificates. Certificates will need to be accessible to the scheduler and workers so likely will need to be included in the Docker image.

```python
>>> from dask_cloudprovider.gcp import GCPCluster
>>> from dask.distributed import Client
>>> from distributed.security import Security
>>> sec = Security(tls_ca_file='cluster_ca.pem',
...                tls_client_cert='cli_cert.pem',
...                tls_client_key='cli_key.pem',
...                require_encryption=True)
>>> cluster = GCPCluster(n_workers=1, security=sec)
>>> client = Client(cluster)
>>> client
<Client: 'tls://10.142.0.29:8786' processes=0 threads=0, memory=0 B>
```

With this approach clients from other processes can connect in the same way.

```python
>>> from dask.distributed import Client
>>> from distributed.security import Security
>>> sec = Security(tls_ca_file='cluster_ca.pem',
...                tls_client_cert='cli_cert.pem',
...                tls_client_key='cli_key.pem',
...                require_encryption=True)
>>> client = Client('tls://10.142.0.29:8786', security=sec)
>>> client
<Client: 'tls://10.142.0.29:8786' processes=0 threads=0, memory=0 B>
```

#### Disabling security

This change makes secure connections the default option. You can also disable SSL/TLS by setting `security` to `False` or `None`.

```python
>>> from dask_cloudprovider.gcp import GCPCluster
>>> cluster = GCPCluster(n_workers=1, security=False)
>>> client = Client(cluster)
>>> client
<Client: 'tcp://10.142.0.29:8786' processes=0 threads=0, memory=0 B>
```