### PR TITLE
Fix typo so we use subnet_id when provided, otherwise use config

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -435,7 +435,7 @@ class EC2Cluster(VMCluster):
         self.gpu_instance = self.instance_type.startswith(("p", "g"))
         self.vpc = vpc if vpc is not None else self.config.get("vpc")
         self.subnet_id = (
-            subnet_id if subnet_id is None else self.config.get("subnet_id")
+            subnet_id if subnet_id is not None else self.config.get("subnet_id")
         )
         self.security_groups = (
             security_groups


### PR DESCRIPTION
We cannot use the provided subnet_id provided to EC2Cluster at the moment because of a typo, this PR fixes it.