### PR TITLE
Add extra docker args option

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -111,13 +111,7 @@ class EC2Instance(VMInterface):
                 "MaxCount": 1,
                 "MinCount": 1,
                 "Monitoring": {"Enabled": False},
-                "UserData": self.cluster.render_cloud_init(
-                    image=self.docker_image,
-                    command=self.command,
-                    gpu_instance=self.gpu_instance,
-                    bootstrap=self.bootstrap,
-                    env_vars=self.env_vars,
-                ),
+                "UserData": self.cluster.render_process_cloud_init(self),
                 "InstanceInitiatedShutdownBehavior": "terminate",
                 "NetworkInterfaces": [
                     {
@@ -291,6 +285,8 @@ class EC2Cluster(VMCluster):
         For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
 
         By default the ``daskdev/dask:latest`` image will be used.
+    docker_args: string (optional)
+        Extra command line arguments to pass to Docker.
     env_vars: dict (optional)
         Environment variables to be passed to the worker.
     silence_logs: bool

--- a/dask_cloudprovider/aws/tests/test_ec2.py
+++ b/dask_cloudprovider/aws/tests/test_ec2.py
@@ -183,9 +183,11 @@ async def test_get_ubuntu_image(ec2_client):
 async def test_get_cloud_init():
     cloud_init = EC2Cluster.get_cloud_init(
         env_vars={"EXTRA_PIP_PACKAGES": "s3fs"},
+        docker_args="--privileged",
     )
     assert "systemctl start docker" in cloud_init
-    assert "-e EXTRA_PIP_PACKAGES=s3fs"
+    assert " -e EXTRA_PIP_PACKAGES=s3fs " in cloud_init
+    assert " --privileged " in cloud_init
 
 
 @pytest.mark.asyncio

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -118,14 +118,7 @@ class AzureVM(VMInterface):
 
         cloud_init = (
             base64.b64encode(
-                self.cluster.render_cloud_init(
-                    image=self.docker_image,
-                    command=self.command,
-                    gpu_instance=self.gpu_instance,
-                    bootstrap=self.bootstrap,
-                    auto_shutdown=self.auto_shutdown,
-                    env_vars=self.env_vars,
-                ).encode("ascii")
+                self.cluster.render_process_cloud_init(self).encode("ascii")
             )
             .decode("utf-8")
             .replace("\n", "")
@@ -284,6 +277,8 @@ class AzureVMCluster(VMCluster):
         For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
 
         By default the ``daskdev/dask:latest`` image will be used.
+    docker_args: string (optional)
+        Extra command line arguments to pass to Docker.
     silence_logs: bool
         Whether or not we should silence logging when setting up the cluster.
     asynchronous: bool

--- a/dask_cloudprovider/azure/tests/test_azurevm.py
+++ b/dask_cloudprovider/azure/tests/test_azurevm.py
@@ -114,3 +114,10 @@ async def test_create_rapids_cluster_sync():
             for w, res in results.items():
                 assert "total" in res["gpu"][0]["fb_memory_usage"].keys()
                 print(res)
+
+
+@pytest.mark.asyncio
+@skip_without_credentials
+async def test_render_cloud_init():
+    cloud_init = AzureVMCluster.get_cloud_init(docker_args="--privileged")
+    assert " --privileged " in cloud_init

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -52,13 +52,7 @@ class Droplet(VMInterface):
             image=self.image,
             size_slug=self.size,
             backups=False,
-            user_data=self.cluster.render_cloud_init(
-                image=self.docker_image,
-                command=self.command,
-                gpu_instance=self.gpu_instance,
-                bootstrap=self.bootstrap,
-                env_vars=self.env_vars,
-            ),
+            user_data=self.cluster.render_process_cloud_init(self),
         )
         await self.cluster.call_async(self.droplet.create)
         for action in self.droplet.get_actions():
@@ -129,6 +123,8 @@ class DropletCluster(VMCluster):
         For GPU instance types the Docker image much have NVIDIA drivers and ``dask-cuda`` installed.
 
         By default the ``daskdev/dask:latest`` image will be used.
+    docker_args: string (optional)
+        Extra command line arguments to pass to Docker.
     env_vars: dict (optional)
         Environment variables to be passed to the worker.
     silence_logs: bool

--- a/dask_cloudprovider/digitalocean/tests/test_droplet.py
+++ b/dask_cloudprovider/digitalocean/tests/test_droplet.py
@@ -63,3 +63,11 @@ async def test_create_cluster(cluster):
             return x + 1
 
         assert await client.submit(inc, 10).result() == 11
+
+
+@pytest.mark.asyncio
+async def test_get_cloud_init():
+    cloud_init = DropletCluster.get_cloud_init(
+        docker_args="--privileged",
+    )
+    assert " --privileged " in cloud_init

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -57,9 +57,10 @@ async def test_init():
 async def test_get_cloud_init():
     skip_without_credentials()
 
-    cloud_init = GCPCluster.get_cloud_init()
+    cloud_init = GCPCluster.get_cloud_init(docker_args="--privileged")
     assert "dask-scheduler" in cloud_init
     assert "# Bootstrap" in cloud_init
+    assert " --privileged " in cloud_init
 
 
 @pytest.mark.asyncio

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -50,7 +50,7 @@ runcmd:
   {% endif %}
 
   # Run container
-  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}={{env_vars[key]}} {% endfor %}{{image}} {{ command }}'
+  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}={{env_vars[key]}} {% endfor %}{%+ if docker_args %}{{docker_args}}{% endif %} {{image}} {{ command }}'
 
   {% if auto_shutdown %}
   # Shutdown when command is done


### PR DESCRIPTION
Add an extra configuration option to specify extra docker arguments.

```python
from dask_cloudprovider.azure import AzureVMCluster

cluster = AzureVMCluster(docker_args="--privileged")

# The scheduler and worker VMs will start their containers with the specified docker args.
#
# E.g `docker run daskdev/dask:latest --privileged dask-scheduler`
```

Closes #223