### PR TITLE
Add on_host_maintenance option in config

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -96,6 +96,7 @@ cloudprovider:
     zone: "us-east1-c" # the zone of of where to launch the instances
     network: "default" # the network/subnetwork in GCP to use
     projectid: "" # name of the google cloud project
+    on_host_maintenance: "TERMINATE"
     machine_type: "n1-standard-1" # size of the machine type to use
     filesystem_size: 50 # amount in GBs of hard drive space to allocate
     ngpus: "" # number of GPUs to use

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -52,6 +52,7 @@ class GCPInstance(VMInterface):
         projectid=None,
         machine_type=None,
         filesystem_size=None,
+        on_host_maintenance=None,
         source_image=None,
         docker_image=None,
         network=None,
@@ -67,6 +68,7 @@ class GCPInstance(VMInterface):
 
         self.cluster = cluster
         self.config = config
+        self.on_host_maintenance = on_host_maintenance or self.config.get("on_host_maintenance")
         self.projectid = projectid or self.config.get("projectid")
         self.zone = zone or self.config.get("zone")
 
@@ -147,7 +149,7 @@ class GCPInstance(VMInterface):
             "labels": {"container-vm": "dask-cloudprovider"},
             "scheduling": {
                 "preemptible": "false",
-                "onHostMaintenance": "TERMINATE",
+                "onHostMaintenance": self.on_host_maintenance.upper(),
                 "automaticRestart": "true",
                 "nodeAffinities": [],
             },
@@ -422,6 +424,8 @@ class GCPCluster(VMCluster):
         You can see a list of GPUs available in each zone with ``gcloud compute accelerator-types list``.
     filesystem_size: int (optional)
         The VM filesystem size in GB. Defaults to ``50``.
+    on_host_maintenance: str (optional)
+        The Host Maintenance GCP option.  Defaults to ``TERMINATE``.
     n_workers: int (optional)
         Number of workers to initialise the cluster with. Defaults to ``0``.
     bootstrap: bool (optional)
@@ -501,7 +505,7 @@ class GCPCluster(VMCluster):
     Source Image: projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20201014
     Docker Image: daskdev/dask:latest
     Machine Type: n1-standard-1
-    Filesytsem Size: 50
+    Filesystem Size: 50
     N-GPU Type:
     Zone: us-east1-c
     Creating scheduler instance
@@ -526,6 +530,7 @@ class GCPCluster(VMCluster):
         zone=None,
         network=None,
         machine_type=None,
+        on_host_maintenance=None,
         source_image=None,
         docker_image=None,
         ngpus=None,
@@ -558,6 +563,7 @@ class GCPCluster(VMCluster):
             "source_image": source_image or self.config.get("source_image"),
             "docker_image": docker_image or self.config.get("docker_image"),
             "filesystem_size": filesystem_size or self.config.get("filesystem_size"),
+            "on_host_maintenance": on_host_maintenance or self.config.get("on_host_maintenance"),
             "zone": zone or self.config.get("zone"),
             "machine_type": self.machine_type,
             "ngpus": ngpus or self.config.get("ngpus"),

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -68,7 +68,9 @@ class GCPInstance(VMInterface):
 
         self.cluster = cluster
         self.config = config
-        self.on_host_maintenance = on_host_maintenance or self.config.get("on_host_maintenance")
+        self.on_host_maintenance = on_host_maintenance or self.config.get(
+            "on_host_maintenance"
+        )
         self.projectid = projectid or self.config.get("projectid")
         self.zone = zone or self.config.get("zone")
 
@@ -563,7 +565,8 @@ class GCPCluster(VMCluster):
             "source_image": source_image or self.config.get("source_image"),
             "docker_image": docker_image or self.config.get("docker_image"),
             "filesystem_size": filesystem_size or self.config.get("filesystem_size"),
-            "on_host_maintenance": on_host_maintenance or self.config.get("on_host_maintenance"),
+            "on_host_maintenance": on_host_maintenance
+            or self.config.get("on_host_maintenance"),
             "zone": zone or self.config.get("zone"),
             "machine_type": self.machine_type,
             "ngpus": ngpus or self.config.get("ngpus"),


### PR DESCRIPTION
fixes #252

With this PR you can optionally define the `on_host_maintenance` configuration with either `TERMINATE` or `MIGRATE`