### PR TITLE
Add option for preemptible instances on GCP

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -61,7 +61,7 @@ class GCPInstance(VMInterface):
         bootstrap=None,
         gpu_instance=None,
         auto_shutdown=None,
-        preemptible=None,
+        preemptible=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -571,7 +571,9 @@ class GCPCluster(VMCluster):
             "gpu_instance": self.gpu_instance,
             "bootstrap": self.bootstrap,
             "auto_shutdown": self.auto_shutdown,
-            "preemptible": preemptible if preemptible is not None else self.config.get("preemptible"),
+            "preemptible": preemptible
+            if preemptible is not None
+            else self.config.get("preemptible"),
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -61,6 +61,7 @@ class GCPInstance(VMInterface):
         bootstrap=None,
         gpu_instance=None,
         auto_shutdown=None,
+        preemptible=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -84,6 +85,7 @@ class GCPInstance(VMInterface):
         self.gpu_instance = gpu_instance
         self.bootstrap = bootstrap
         self.auto_shutdown = auto_shutdown
+        self.preemptible = preemptible
 
         self.general_zone = "-".join(self.zone.split("-")[:2])  # us-east1-c -> us-east1
 
@@ -146,9 +148,9 @@ class GCPInstance(VMInterface):
             },
             "labels": {"container-vm": "dask-cloudprovider"},
             "scheduling": {
-                "preemptible": "false",
+                "preemptible": ("true" if self.preemptible else "false"),
                 "onHostMaintenance": "TERMINATE",
-                "automaticRestart": "true",
+                "automaticRestart": ("false" if self.preemptible else "true"),
                 "nodeAffinities": [],
             },
             "shieldedInstanceConfig": {
@@ -447,6 +449,8 @@ class GCPCluster(VMCluster):
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
+    preemptible: bool (optional)
+        Whether to use preemptible instances in this cluster. Defaults to ``False``.
 
     Examples
     --------
@@ -533,6 +537,7 @@ class GCPCluster(VMCluster):
         filesystem_size=None,
         auto_shutdown=None,
         bootstrap=True,
+        preemptible=None,
         **kwargs,
     ):
 
@@ -566,6 +571,7 @@ class GCPCluster(VMCluster):
             "gpu_instance": self.gpu_instance,
             "bootstrap": self.bootstrap,
             "auto_shutdown": self.auto_shutdown,
+            "preemptible": preemptible if preemptible is not None else self.config.get("preemptible"),
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -270,6 +270,7 @@ class GCPScheduler(SchedulerMixin, GCPInstance):
     """Scheduler running in a GCP instance."""
 
     def __init__(self, *args, **kwargs):
+        kwargs.pop("preemptible", None)  # scheduler instances are not preemptible
         super().__init__(*args, **kwargs)
 
     async def start(self):
@@ -450,7 +451,7 @@ class GCPCluster(VMCluster):
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
     preemptible: bool (optional)
-        Whether to use preemptible instances in this cluster. Defaults to ``False``.
+        Whether to use preemptible instances for workers in this cluster. Defaults to ``False``.
 
     Examples
     --------


### PR DESCRIPTION
Here's a simple fix for #255.

As it stands, if preemptible instances are enabled, all instances in the cluster - including the scheduler - are preemptible. It would be better if the scheduler instance was always a standard (non-preemptible) instance. Suggestions for how to do that would be very welcome.