### PR TITLE
Critical Fix for #257.

### DIFF
--- a/dask_cloudprovider/aws/tests/test_ec2.py
+++ b/dask_cloudprovider/aws/tests/test_ec2.py
@@ -186,7 +186,7 @@ async def test_get_cloud_init():
         docker_args="--privileged",
     )
     assert "systemctl start docker" in cloud_init
-    assert " -e EXTRA_PIP_PACKAGES=s3fs " in cloud_init
+    assert ' -e EXTRA_PIP_PACKAGES="s3fs" ' in cloud_init
     assert " --privileged " in cloud_init
 
 

--- a/dask_cloudprovider/generic/cloud-init.yaml.j2
+++ b/dask_cloudprovider/generic/cloud-init.yaml.j2
@@ -50,7 +50,7 @@ runcmd:
   {% endif %}
 
   # Run container
-  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}={{env_vars[key]}} {% endfor %}{%+ if docker_args %}{{docker_args}}{% endif %} {{image}} {{ command }}'
+  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}="{{env_vars[key]}}" {% endfor %}{%+ if docker_args %}{{docker_args}}{% endif %} {{image}} {{ command }}'
 
   {% if auto_shutdown %}
   # Shutdown when command is done


### PR DESCRIPTION
When an env_vars variable is passed to the docker run command and
it contains one or more space characters, we need to wrapp the
value in double quotes.