### PR TITLE
Fix case sensitivity in AzureVMCluster GPU instance checks

### DIFF
--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -463,7 +463,9 @@ class AzureVMCluster(VMCluster):
         )
         if self.scheduler_vm_size is None:
             self.scheduler_vm_size = self.vm_size
-        self.gpu_instance = "NC" in self.vm_size or "ND" in self.vm_size
+        self.gpu_instance = (
+            "_NC" in self.vm_size.upper() or "_ND" in self.vm_size.upper()
+        )
         self.vm_image = self.config.get("vm_image")
         for key in vm_image:
             self.vm_image[key] = vm_image[key]


### PR DESCRIPTION
It turns out that the Azure API is case insensitive so it is possible to select an image size like `standard_nc6s_v3` instead of `Standard_NC6s_v3`.

Fixing the vm size check to be case insensitive and also look for `_` prefix to avoid `ND` matching in `standard`.

cc @manuelreyesgomez