### PR TITLE
Add debug flag to VMCluster

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -298,6 +298,8 @@ class EC2Cluster(VMCluster):
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
+    debug: bool, optional
+        More information will be printed when constructing clusters to enable debugging.
 
     Notes
     -----
@@ -402,6 +404,7 @@ class EC2Cluster(VMCluster):
         key_name=None,
         iam_instance_profile=None,
         docker_image=None,
+        debug=False,
         **kwargs,
     ):
         self.boto_session = aiobotocore.get_session()
@@ -452,6 +455,7 @@ class EC2Cluster(VMCluster):
             if iam_instance_profile is not None
             else self.config.get("iam_instance_profile")
         )
+        self.debug = debug
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -471,4 +475,4 @@ class EC2Cluster(VMCluster):
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}
-        super().__init__(**kwargs)
+        super().__init__(debug=debug, **kwargs)

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -288,6 +288,8 @@ class AzureVMCluster(VMCluster):
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
+    debug: bool, optional
+        More information will be printed when constructing clusters to enable debugging.
 
     Examples
     --------
@@ -412,6 +414,7 @@ class AzureVMCluster(VMCluster):
         bootstrap: bool = None,
         auto_shutdown: bool = None,
         docker_image=None,
+        debug: bool = False,
         **kwargs,
     ):
         self.config = dask.config.get("cloudprovider.azure.azurevm", {})
@@ -478,6 +481,7 @@ class AzureVMCluster(VMCluster):
             else self.config.get("auto_shutdown")
         )
         self.docker_image = docker_image or self.config.get("docker_image")
+        self.debug = debug
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -495,4 +499,4 @@ class AzureVMCluster(VMCluster):
             **self.options,
         }
         self.worker_options = {"vm_size": self.vm_size, **self.options}
-        super().__init__(**kwargs)
+        super().__init__(debug=debug, **kwargs)

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -136,6 +136,8 @@ class DropletCluster(VMCluster):
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
+    debug: bool, optional
+        More information will be printed when constructing clusters to enable debugging.
 
     Examples
     --------
@@ -193,11 +195,13 @@ class DropletCluster(VMCluster):
         region: str = None,
         size: str = None,
         image: str = None,
+        debug: bool = False,
         **kwargs,
     ):
         self.config = dask.config.get("cloudprovider.digitalocean", {})
         self.scheduler_class = DropletScheduler
         self.worker_class = DropletWorker
+        self.debug = debug
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -207,4 +211,4 @@ class DropletCluster(VMCluster):
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}
-        super().__init__(**kwargs)
+        super().__init__(debug=debug, **kwargs)

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -458,6 +458,8 @@ class GCPCluster(VMCluster):
         be created automatically. Default is ``True``.
     preemptible: bool (optional)
         Whether to use preemptible instances for workers in this cluster. Defaults to ``False``.
+    debug: bool, optional
+        More information will be printed when constructing clusters to enable debugging.
 
     Examples
     --------
@@ -546,6 +548,7 @@ class GCPCluster(VMCluster):
         auto_shutdown=None,
         bootstrap=True,
         preemptible=None,
+        debug=False,
         **kwargs,
     ):
 
@@ -564,6 +567,7 @@ class GCPCluster(VMCluster):
         )
         self.machine_type = machine_type or self.config.get("machine_type")
         self.gpu_instance = "gpu" in self.machine_type or bool(ngpus)
+        self.debug = debug
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -588,7 +592,7 @@ class GCPCluster(VMCluster):
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}
 
-        super().__init__(**kwargs)
+        super().__init__(debug=debug, **kwargs)
 
 
 class GCPCompute:

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -195,10 +195,12 @@ class VMCluster(SpecCluster):
     asynchronous: bool
         If this is intended to be used directly within an event loop with
         async/await
-    security : Security or bool, optional
+    security: Security or bool, optional
         Configures communication security in this cluster. Can be a security
         object, or True. If True, temporary self-signed credentials will
         be created automatically. Default is ``True``.
+    debug: bool, optional
+        More information will be printed when constructing clusters to enable debugging.
 
     """
 
@@ -224,6 +226,7 @@ class VMCluster(SpecCluster):
         env_vars: dict = {},
         security: bool = True,
         protocol: str = None,
+        debug: bool = False,
         **kwargs,
     ):
         if self.scheduler_class is None or self.worker_class is None:
@@ -249,6 +252,8 @@ class VMCluster(SpecCluster):
                 self.protocol = "tcp"
         else:
             self.protocol = protocol
+
+        self.debug = debug
 
         if self.security and self.security.require_encryption:
             dask.config.set(
@@ -338,7 +343,11 @@ class VMCluster(SpecCluster):
         loader = FileSystemLoader([os.path.dirname(os.path.abspath(__file__))])
         environment = Environment(loader=loader)
         template = environment.get_template("cloud-init.yaml.j2")
-        return template.render(**kwargs)
+        cloud_init = template.render(**kwargs)
+        if self.debug:
+            print("\nCloud init\n==========\n\n")
+            print(cloud_init)
+        return cloud_init
 
     @classmethod
     def get_cloud_init(cls, *args, **kwargs):


### PR DESCRIPTION
Adds a debug flag to all `VMCluster` based cluster managers. This can then be used for printing more verbose output when starting clusters. For now, it prints the `cloud_init` file at render time.