### PR TITLE
Correct ec2 action name in documentation

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1292,7 +1292,7 @@ class FargateCluster(ECSCluster):
                         "ec2:CreateSecurityGroup",
                         "ec2:CreateTags",
                         "ec2:DescribeNetworkInterfaces",
-                        "ec2:DescribeSecurityGroup",
+                        "ec2:DescribeSecurityGroups",
                         "ec2:DescribeSubnets",
                         "ec2:DescribeVpcs",
                         "ec2:DeleteSecurityGroup",
@@ -1339,7 +1339,7 @@ class FargateCluster(ECSCluster):
                     "Action": [
                         "ec2:CreateTags",
                         "ec2:DescribeNetworkInterfaces",
-                        "ec2:DescribeSecurityGroup",
+                        "ec2:DescribeSecurityGroups",
                         "ec2:DescribeSubnets",
                         "ec2:DescribeVpcs",
                         "ecs:DescribeTasks",


### PR DESCRIPTION
I was tripping over a small documentation typo the other day when working with the ECS/Fargate provider and realised that there is a missing plural to one of the listed ec2 actions for the required IAM policies.

`ec2:DescribeSecurityGroups` is the correct name of the action, this is listed in the documentation [here](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html) and can also be verified in the IAM console where IAM will complain on not recognising `ec2:DescribeSecurityGroup` when editing a policy.

A very small documentation contribution, thanks for all the work with this!