### PR TITLE
Added support for using Marketplace VM images with plans in AzureVMCluster

### DIFF
--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -43,7 +43,7 @@ class AzureVM(VMInterface):
         env_vars: dict = {},
         bootstrap: bool = None,
         auto_shutdown: bool = None,
-        marketplace_plan : dict = {},
+        marketplace_plan: dict = {},
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -159,12 +159,18 @@ class AzureVM(VMInterface):
         }
 
         if self.marketplace_plan:
-            # Ref: https://docs.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update#create-a-vm-with-a-marketplace-image-plan.
+            # Ref: https://docs.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update#create-a-vm-with-a-marketplace-image-plan. # noqa
             # Creating a marketplace VM with a plan will override default vm_image values.
             vm_parameters["plan"] = self.marketplace_plan
-            vm_parameters["storage_profile"]["image_reference"]["sku"] = self.marketplace_plan["name"]
-            vm_parameters["storage_profile"]["image_reference"]["publisher"] = self.marketplace_plan["publisher"]
-            vm_parameters["storage_profile"]["image_reference"]["offer"] = self.marketplace_plan["product"]
+            vm_parameters["storage_profile"]["image_reference"][
+                "sku"
+            ] = self.marketplace_plan["name"]
+            vm_parameters["storage_profile"]["image_reference"][
+                "publisher"
+            ] = self.marketplace_plan["publisher"]
+            vm_parameters["storage_profile"]["image_reference"][
+                "offer"
+            ] = self.marketplace_plan["product"]
             vm_parameters["storage_profile"]["image_reference"]["version"] = "latest"
             self.cluster._log("Using Marketplace VM image with a Plan")
 
@@ -526,12 +532,15 @@ class AzureVMCluster(VMCluster):
         )
         self.docker_image = docker_image or self.config.get("docker_image")
         self.debug = debug
-        self.marketplace_plan = marketplace_plan or self.config.get('marketplace_plan')
+        self.marketplace_plan = marketplace_plan or self.config.get("marketplace_plan")
         if self.marketplace_plan:
-            # Check that self.marketplace_plan contains the right options with values 
-            if not all(self.marketplace_plan.get(item, "")!="" for item in ['name', 'publisher', 'product']):
+            # Check that self.marketplace_plan contains the right options with values
+            if not all(
+                self.marketplace_plan.get(item, "") != ""
+                for item in ["name", "publisher", "product"]
+            ):
                 raise ConfigError(
-                """To create a virtual machine from Marketplace image or a custom image sourced
+                    """To create a virtual machine from Marketplace image or a custom image sourced
                 from a Marketplace image with a plan, all 3 fields 'name', 'publisher' and 'product' must be passed."""
                 )
 
@@ -546,7 +555,7 @@ class AzureVMCluster(VMCluster):
             "bootstrap": self.bootstrap,
             "auto_shutdown": self.auto_shutdown,
             "docker_image": self.docker_image,
-            "marketplace_plan": self.marketplace_plan
+            "marketplace_plan": self.marketplace_plan,
         }
         self.scheduler_options = {
             "vm_size": self.scheduler_vm_size,

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -70,6 +70,10 @@ cloudprovider:
         version: "latest"
       bootstrap: true # It is assumed that the VHD does not have Docker and needs bootstrapping. Set this to false if using a custom VHD with Docker already installed.
       auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.
+      marketplace_plan:  null # This needs to be passed in if the user wants to use a Marketplace VM with a plan.
+        # name: "ngc-base-version-21-02-2"
+        # publisher: "nvidia"
+        # product: "ngc_azure_17_11"
 
   digitalocean:
     token: null # API token for interacting with the Digital Ocean API

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         "azure-mgmt-compute>=18.0.0",
         "azure-mgmt-network>=16.0.0",
         "azure-cli-core>=2.15.1",
+        "msrestazure",
     ],
     "digitalocean": ["python-digitalocean>=1.15.0"],
     "gcp": ["google-api-python-client>=1.12.5", "google-auth>=1.23.0"],


### PR DESCRIPTION
This PR :

- Adds support for using Marketplace VM images that has plans while creating AzureVM Cluster. 
- Closes [Issue#293](https://github.com/dask/dask-cloudprovider/issues/293) 

**More Details on Azure Marketplace VM issue**

Creating a virtual machine from Marketplace image or a custom image sourced from a Marketplace image requires Plan information in the request when using the python sdk or cli. This is applicable to the images which has plans. For example the pre-build *NVIDIA GPU-Optimized Image for AI & HPC* image made available by NVIDIA.

As an example, the input fields for creating a VM using *NVIDIA GPU-Optimized Image for AI & HPC* 21.02.2 can be found using the following: 
```bash
 >> az vm image show --publisher nvidia --offer ngc_azure_17_11 --sku ngc-base-version-21-02-2 --version 21.02.2
{
  "automaticOsUpgradeProperties": {
    "automaticOsUpgradeSupported": false
  },
  "dataDiskImages": [],
  "disallowed": {
    "vmDiskType": "Unmanaged"
  },
  "extendedLocation": null,
  "features": [
    {
      "name": "IsAcceleratedNetworkSupported",
      "value": "True"
    }
  ],
  "hyperVGeneration": "V1",
  "id": "/Subscriptions/<truncated subscription id>/Providers/Microsoft.Compute/Locations/westus/Publishers/nvidia/ArtifactTypes/VMImage/Offers/ngc_azure_17_11/Skus/ngc-base-version-21-02-2/Versions/21.02.2",
  "location": "westus",
  "name": "21.02.2",
  "osDiskImage": {
    "operatingSystem": "Linux",
    "sizeInBytes": 34359738880,
    "sizeInGb": 32
  },
  "plan": {
    "name": "ngc-base-version-21-02-2",
    "product": "ngc_azure_17_11",
    "publisher": "nvidia"
  },
  "tags": null
}
```
The `plan` field is an additional field that needs to be passed in this case. The contains of this field is essentially similar to what we have in `vm_image` field, just the names of the keys are different. 

**Soluton:**
I introduced a flag `is_marketplace_vm_with_plan`, which is by default False. You should set it True if you want to use a marketplace VM image with a plan. If set to True, this will extract the `name` , `product` and `publisher` information from `vm_image` and sets to a upper level key `plan`. 

**Caveat**
Inferring if the user passed in image is a marketplace image or if the market place image has a plan or not is not automatic. If the user accidentally sets the `is_marketplace_vm_with_plan` to True and don't use a Marketplace VM or an image with a Plan, then it would throw an error. 