### PR TITLE
Check for pending tasks during _cleanup_stale_resources for ECS

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1404,7 +1404,7 @@ async def _cleanup_stale_resources():
                 if set(DEFAULT_TAGS.items()) <= set(
                     aws_to_dict(cluster["tags"]).items()
                 ):
-                    if cluster["runningTasksCount"] == 0:
+                    if cluster["runningTasksCount"] == 0 and cluster["pendingTasksCount"] == 0:
                         clusters_to_delete.append(cluster["clusterArn"])
                     else:
                         active_clusters.append(cluster["clusterName"])


### PR DESCRIPTION
The code would try and delete clusters with pending tasks resulting in failure.  Added check for 0 pending tasks as well as running tasks.