### PR TITLE
[Dask] Add support for AWS Fargate Spot clusters

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -98,8 +98,9 @@ class Task:
         Defaults to False, i.e. public IP.
 
     fargate_capacity_provider: str (optional)
-        If launched on Fargate, use this capacity provider (FARGATE/FARGATE_SPOT).
-        If not set, launchType=FARGATE will be used.
+        If cluster is launched on Fargate with `fargate_spot=True`, use this capacity provider
+        (should be either `FARGATE` or `FARGATE_SPOT`).
+        If not set, `launchType=FARGATE` will be used.
         Defaults to None.
 
     task_kwargs: dict (optional)
@@ -467,8 +468,10 @@ class ECSCluster(SpecCluster):
 
         Defaults to ``False``. You must provide an existing cluster.
     fargate_spot: bool (optional)
-        Select whether or not to run cluster using Fargate Spot. This will run workers on FARGATE_SPOT
-        and scheduler on FARGATE capacity providers.
+        Select whether or not to run cluster using Fargate Spot with workers running on spot capacity.
+        If `fargate_scheduler=True` and `fargate_workers=True`, this will make sure worker tasks will use
+        `fargate_capacity_provider=FARGATE_SPOT` and scheduler task will use
+        `fargate_capacity_provider=FARGATE` capacity providers.
 
         Defaults to ``False``. You must provide an existing cluster.
     image: str (optional)

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -283,9 +283,7 @@ class Task:
                         kwargs["launchType"] = "FARGATE"
                     else:
                         kwargs["capacityProviderStrategy"] = [
-                            {
-                                "capacityProvider": self._fargate_capacity_provider
-                            }
+                            {"capacityProvider": self._fargate_capacity_provider}
                         ]
 
                 async with self._client("ecs") as ecs:


### PR DESCRIPTION
Runs Workers on `FARGATE_SPOT` and Scheduler on `FARGATE` capacity providers if `FargateCluster(fargate_spot=True)`