### PR TITLE
VMCluster should name wokers based on SpecCluster new_worker_name()

### DIFF
--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -323,7 +323,9 @@ class VMCluster(SpecCluster):
             "options": self.scheduler_options,
         }
         self.new_spec = {"cls": self.worker_class, "options": self.worker_options}
-        self.worker_spec = {i: self.new_spec for i in range(self._n_workers)}
+        self.worker_spec = {
+            self._new_worker_name(i): self.new_spec for i in range(self._n_workers)
+        }
 
         with warn_on_duration(
             "10s",


### PR DESCRIPTION
This was already working for new VMs created using the scale() feature of SpecCluster, but this change allows subclasses of VMCluster to specify their own _new_worker_name, and its initial n_workers (created in _start()) will be named accordingly.