### PR TITLE
Pass appropriate kwargs to _cleanup_stale_resources for ECS

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -812,9 +812,9 @@ class ECSCluster(SpecCluster):
             self._skip_cleanup = self.config.get("skip_cleanup")
         if not self._skip_cleanup:
             await _cleanup_stale_resources(
-                aws_access_key_id = self.config.get("aws_access_key_id"),
-                aws_secret_access_key = self.config.get("aws_secret_access_key"),
-                region_name = self.config.get("region_name"),
+                aws_access_key_id=self.config.get("aws_access_key_id"),
+                aws_secret_access_key=self.config.get("aws_secret_access_key"),
+                region_name=self.config.get("region_name"),
             )
 
         if self._fargate_scheduler is None:


### PR DESCRIPTION
On creation of an ECS cluster, an error is thrown if `~/.aws/config` does not exist. It will also only check for stale resources in the default region specified in `~/.aws/config`.

I've updated `_cleanup_stale_resources` to allow passing of kwargs to fix this. `ECSCluster(region_name="xxxx")` will now check for stale resources in the specified region before creation.

This PR should also fix issue #71.