### PR TITLE
Drop python 37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout source
@@ -50,7 +50,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Run import tests
         shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install pypa/build
         run: python -m pip install build wheel

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: "3.8"
   install:
     - method: pip
       path: .

--- a/ci/environment-3.10.yml
+++ b/ci/environment-3.10.yml
@@ -1,0 +1,38 @@
+name: dask-cloudprovider-test
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.10
+  - nomkl
+  - pip
+  # Dask
+  - dask
+  # testing / CI
+  - flake8
+  - ipywidgets
+  - pytest
+  - pytest-asyncio
+  - black >=20.8b1
+  - pyyaml
+  # dask dependencies
+  - cloudpickle
+  - toolz
+  - cytoolz
+  - numpy
+  - partd
+  # distributed dependencies
+  - click >=6.6
+  - msgpack-python
+  - psutil >=5.0
+  - six
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib
+  - tornado >=5
+  - zict >=0.1.3
+  # `event_loop_policy` change See https://github.com/dask/distributed/pull/4212
+  - pytest-asyncio >=0.14.0
+  - pytest-timeout
+  - pip:
+      - git+https://github.com/dask/dask.git@main
+      - git+https://github.com/dask/distributed@main

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -3,9 +3,11 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   - nomkl
   - pip
+  # Dask
+  - dask
   # testing / CI
   - flake8
   - ipywidgets

--- a/ci/scripts/test_imports.sh
+++ b/ci/scripts/test_imports.sh
@@ -3,9 +3,9 @@ set -o errexit
 
 
 test_import () {
-    echo "Create environment: python=3.7 $1"
+    echo "Create environment: python=3.8 $1"
     # Create an empty environment
-    conda create -q -y -n test-imports -c conda-forge python=3.7
+    conda create -q -y -n test-imports -c conda-forge python=3.8
     conda activate test-imports
     pip install -e .[$1]
     echo "python -c '$2'"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
     "azure": [
         "azure-mgmt-compute>=18.0.0,<19",
         "azure-mgmt-network>=16.0.0,<17",
-        "azure-cli-core>=2.15.1,<3",
+        "azure-cli-core>=2.15.1,<2.21.0",
         "msrestazure",
         "azure-identity",
     ],

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
     [console_scripts]
     dask-ecs=dask_cloudprovider.cli.ecs:go
     """,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Dask dropped Python 3.7 recently so just following up here with the same. Also added CI for 3.9 and 3.10.