### PR TITLE
gcp: configure scheduler port

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -338,9 +338,12 @@ class GCPWorker(GCPInstance):
         self.scheduler = scheduler
         self.worker_class = worker_class
         self.name = f"dask-{self.cluster.uuid}-worker-{str(uuid.uuid4())[:8]}"
-        internal_scheduler = (
-            f"{self.cluster.protocol}://{self.cluster.scheduler_internal_ip}:{self.cluster.scheduler_port}"
+        proto, ip, port = (
+            self.cluster.protocol,
+            self.cluster.scheduler_internal_ip,
+            self.cluster.scheduler_port,
         )
+        internal_scheduler = f"{proto}://{ip}:{port}"
         self.command = " ".join(
             [
                 self.set_env,

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -72,6 +72,7 @@ class SchedulerMixin(object):
     ):
         super().__init__(*args, **kwargs)
         self.name = f"dask-{self.cluster.uuid}-scheduler"
+        self.port = scheduler_options.get("port", 8786)
         self.command = " ".join(
             [
                 self.set_env,
@@ -85,7 +86,7 @@ class SchedulerMixin(object):
     async def start(self):
         self.cluster._log("Creating scheduler instance")
         ip = await self.create_vm()
-        self.address = f"{self.cluster.protocol}://{ip}:8786"
+        self.address = f"{self.cluster.protocol}://{ip}:{self.port}"
         await self.wait_for_scheduler()
         await super().start()
 


### PR DESCRIPTION
It's possible to configure the scheduler port (using `scheduler_options={"port":"<custom>"}`) but it's not taken into account in GCP.

This commit gets the scheduler_port from `scheduler_options` and defines `SchedulerMixin.port` that is then reused by `GCPScheduler` and `GCPWorker` to define the scheduler address.