### PR TITLE
Remove py3 check

### DIFF
--- a/dask_cloudprovider/cli/ecs.py
+++ b/dask_cloudprovider/cli/ecs.py
@@ -3,7 +3,7 @@ from asyncio import sleep
 import sys
 
 import click
-from distributed.cli.utils import check_python_3, install_signal_handlers
+from distributed.cli.utils import install_signal_handlers
 from distributed.core import Status
 from tornado.ioloop import IOLoop, TimeoutError
 
@@ -234,7 +234,6 @@ def main(
 
 
 def go():
-    check_python_3()
     main()
 
 


### PR DESCRIPTION
This was removed in the latest Dask release because we are Python 3 everywhere.