### PR TITLE
Make SchedulerAddress awaitable

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1005,6 +1005,12 @@ class ECSCluster(SpecCluster):
                 def __init__(self_):
                     self_.address = self._scheduler_address
 
+                def __await__(self):
+                    async def _():
+                        return self
+
+                    return _().__await__()
+
             self.scheduler = SchedulerAddress()
 
         with warn_on_duration(


### PR DESCRIPTION
The `SchedulerAddress` object can be used as a proxy for the `Scheduler` object and therefore needs to be awaitable.

Fixes #346