### PR TITLE
 Fargate with spot instances fails with InvalidParameterException #328

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1037,9 +1037,9 @@ class ECSCluster(SpecCluster):
         self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(
-                clusterName=self.cluster_name, 
+                clusterName=self.cluster_name,
                 tags=dict_to_aws(self.tags),
-                capacityProviders=['FARGATE', 'FARGATE_SPOT'],
+                capacityProviders=["FARGATE", "FARGATE_SPOT"],
             )
         weakref.finalize(self, self.sync, self._delete_cluster)
         return response["cluster"]["clusterArn"]

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1039,7 +1039,7 @@ class ECSCluster(SpecCluster):
             response = await ecs.create_cluster(
                 clusterName=self.cluster_name, 
                 tags=dict_to_aws(self.tags),
-                capacityProviders=['FARGATE', 'FARGATE_SPOT']
+                capacityProviders=['FARGATE', 'FARGATE_SPOT'],
             )
         weakref.finalize(self, self.sync, self._delete_cluster)
         return response["cluster"]["clusterArn"]

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1037,7 +1037,9 @@ class ECSCluster(SpecCluster):
         self.cluster_name = self.cluster_name.format(uuid=str(uuid.uuid4())[:10])
         async with self._client("ecs") as ecs:
             response = await ecs.create_cluster(
-                clusterName=self.cluster_name, tags=dict_to_aws(self.tags)
+                clusterName=self.cluster_name, 
+                tags=dict_to_aws(self.tags),
+                capacityProviders=['FARGATE', 'FARGATE_SPOT']
             )
         weakref.finalize(self, self.sync, self._delete_cluster)
         return response["cluster"]["clusterArn"]


### PR DESCRIPTION
ECS would not allow FARGATE_SPOT tasks to be created without FARGATE_SPOT being added as a capacityProvider to the cluster.

Also added FARGATE to support schedulers (on demand) and workers (spot) within the same cluster.