### PR TITLE
Add support for EC2 tags on instance creation

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -143,7 +143,7 @@ class EC2Instance(VMInterface):
                         "ResourceType": "volume",
                         "Tags": dict_to_aws(self.volume_tags, upper=True),
                     },
-                ]
+                ],
             }
 
             if self.key_name:

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -142,7 +142,7 @@ class EC2Instance(VMInterface):
                     {
                         "ResourceType": "volume",
                         "Tags": dict_to_aws(self.volume_tags, upper=True),
-                    }
+                    },
                 ]
             }
 

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -141,7 +141,7 @@ class EC2Instance(VMInterface):
                     },
                     {
                         "ResourceType": "volume",
-                        "Tags": dict_to_aws(self.instance_tags, upper=True)
+                        "Tags": dict_to_aws(self.volume_tags, upper=True)
                     }
                 ]
             }
@@ -325,7 +325,7 @@ class EC2Cluster(VMCluster):
         Tags to be applied to all EC2 instances upon creation. By default, includes
         "createdBy": "dask-cloudprovider"
     volume_tags: dict, optional
-        Tags to be applied to all EC2 volumes upon creation. By default, includes
+        Tags to be applied to all EBS volumes upon creation. By default, includes
         "createdBy": "dask-cloudprovider"
 
     Notes

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -29,7 +29,7 @@ except ImportError as e:
     )
     raise ImportError(msg) from e
 
-DEFAULT_INSTANCE_TAGS = {
+DEFAULT_TAGS = {
     "createdBy": "dask-cloudprovider"
 }  # tags to apply to all created instances
 
@@ -487,10 +487,10 @@ class EC2Cluster(VMCluster):
         self.debug = debug
 
         instance_tags = instance_tags if instance_tags is not None else {}
-        self.instance_tags = {**instance_tags, **DEFAULT_INSTANCE_TAGS}
+        self.instance_tags = {**instance_tags, **DEFAULT_TAGS}
 
         volume_tags = volume_tags if volume_tags is not None else {}
-        self.volume_tags = {**volume_tags, **DEFAULT_INSTANCE_TAGS}
+        self.volume_tags = {**volume_tags, **DEFAULT_TAGS}
 
         self.options = {
             "cluster": self,

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -29,10 +29,6 @@ except ImportError as e:
     )
     raise ImportError(msg) from e
 
-DEFAULT_TAGS = {
-    "createdBy": "dask-cloudprovider"
-}  # tags to apply to all created instances
-
 
 class EC2Instance(VMInterface):
     def __init__(

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -13,7 +13,7 @@ from dask_cloudprovider.aws.helper import (
     get_default_vpc,
     get_vpc_subnets,
     get_security_group,
-    dict_to_aws
+    dict_to_aws,
 )
 from dask_cloudprovider.utils.timeout import Timeout
 
@@ -137,11 +137,11 @@ class EC2Instance(VMInterface):
                 "TagSpecifications": [
                     {
                         "ResourceType": "instance",
-                        "Tags": dict_to_aws(self.instance_tags, upper=True)
+                        "Tags": dict_to_aws(self.instance_tags, upper=True),
                     },
                     {
                         "ResourceType": "volume",
-                        "Tags": dict_to_aws(self.volume_tags, upper=True)
+                        "Tags": dict_to_aws(self.volume_tags, upper=True),
                     }
                 ]
             }

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -55,8 +55,8 @@ class EC2Instance(VMInterface):
         filesystem_size=None,
         key_name=None,
         iam_instance_profile=None,
-        instance_tags: dict,
-        volume_tags: dict,
+        instance_tags: None,
+        volume_tags: None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -487,10 +487,10 @@ class EC2Cluster(VMCluster):
         self.debug = debug
 
         instance_tags = instance_tags if instance_tags is not None else {}
-        self.instance_tags = {**instance_tags, **DEFAULT_TAGS}
+        self.instance_tags = {**instance_tags, **self.config.get("instance_tags")}
 
         volume_tags = volume_tags if volume_tags is not None else {}
-        self.volume_tags = {**volume_tags, **DEFAULT_TAGS}
+        self.volume_tags = {**volume_tags, **self.config.get("volume_tags")}
 
         self.options = {
             "cluster": self,

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -51,6 +51,10 @@ cloudprovider:
     iam_instance_profile: {} # Iam role to assign to instances
       # Arn: 'string'
       # Name: 'string'
+    instance_tags:
+      createdBy: dask-cloudprovider
+    volume_tags:
+      createdBy: dask-cloudprovider
 
   azure:
     location: null # The Azure location to launch your cluster


### PR DESCRIPTION
Some organizations (including mine) require resources to be tagged on creation.

This PR adds this feature. AWS supports tagging instances and volumes on launch (see [the docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html)).

I implemented this by adding two optional parameters to `EC2Cluster`: `instance_tags` and `volume_tags`. These are passed in as dictionaries and then formatted for AWS, similarly to how this is done for `ECSCluster` tags.