### PR TITLE
Ability to use EC2 private IP address

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -124,7 +124,9 @@ class EC2Instance(VMInterface):
                 "InstanceInitiatedShutdownBehavior": "terminate",
                 "NetworkInterfaces": [
                     {
-                        "AssociatePublicIpAddress": False if self.use_private_ip else True,
+                        "AssociatePublicIpAddress": False
+                        if self.use_private_ip
+                        else True,
                         "DeleteOnTermination": True,
                         "Description": "private" if self.use_private_ip else "public",
                         "DeviceIndex": 0,


### PR DESCRIPTION
This PR adds the ability to set up an EC2 cluster whose instances do not have public IP addresses, and the scheduler/workers communicate via private IP.