### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,3 +1,3 @@
 numpydoc
 sphinx
-dask_sphinx_theme>=2
+dask-sphinx-theme>=3.0.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -86,7 +86,9 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "default"
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell