### PR TITLE
ECSCluster attr cleanup

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -808,10 +808,29 @@ class ECSCluster(SpecCluster, ConfigMixin):
 
         self.config = dask.config.get("cloudprovider.ecs", {})
 
-        for attr in ["region_name", "aws_access_key_id", "aws_secret_access_key", "fargate_scheduler", "fargate_workers",
-                     "fargate_spot", "fargate_use_private_ip", "tags", "environment", "scheduler_cpu", "scheduler_mem",
-                     "scheduler_timeout", "worker_cpu", "worker_nthreads", "worker_mem", "n_workers", "cluster_name_template",
-                     "platform_version", "task_role_policies", "vpc", "cloudwatch_logs_default_retention"]:
+        for attr in [
+            "region_name",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "fargate_scheduler",
+            "fargate_workers",
+            "fargate_spot",
+            "fargate_use_private_ip",
+            "tags",
+            "environment",
+            "scheduler_cpu",
+            "scheduler_mem",
+            "scheduler_timeout",
+            "worker_cpu",
+            "worker_nthreads",
+            "worker_mem",
+            "n_workers",
+            "cluster_name_template",
+            "platform_version",
+            "task_role_policies",
+            "vpc",
+            "cloudwatch_logs_default_retention",
+        ]:
             self.update_attr_from_config(attr=attr, private=True)
 
         # Cleanup any stale resources before we start

--- a/dask_cloudprovider/aws/helper.py
+++ b/dask_cloudprovider/aws/helper.py
@@ -24,6 +24,19 @@ def get_sleep_duration(current_try, min_sleep_millis=10, max_sleep_millis=5000):
     return min(current_sleep_millis, max_sleep_millis) / 1000  # return in seconds
 
 
+class ConfigMixin:
+
+    def update_attr_from_config(self, attr: str, private: bool):
+        """Update class attribute of given cluster based on config, if not already set. If `private` is True, the class
+        attribute will be prefixed with an underscore.
+
+        This mixin can be applied to any class that has a config dict attribute.
+        """
+        prefix = "_" if private else ""
+        if getattr(self, f"{prefix}{attr}") is None:
+            setattr(self, f"{prefix}{attr}", self.config.get(attr))
+
+
 async def get_latest_ami_id(client, name_glob, owner):
     images = await client.describe_images(
         Filters=[

--- a/dask_cloudprovider/aws/helper.py
+++ b/dask_cloudprovider/aws/helper.py
@@ -25,7 +25,6 @@ def get_sleep_duration(current_try, min_sleep_millis=10, max_sleep_millis=5000):
 
 
 class ConfigMixin:
-
     def update_attr_from_config(self, attr: str, private: bool):
         """Update class attribute of given cluster based on config, if not already set. If `private` is True, the class
         attribute will be prefixed with an underscore.

--- a/dask_cloudprovider/aws/tests/test_helper.py
+++ b/dask_cloudprovider/aws/tests/test_helper.py
@@ -51,9 +51,7 @@ def test_config_mixin():
         attr2 = None
 
         def __init__(self):
-            self.config = {
-                "attr2": "bar"
-            }
+            self.config = {"attr2": "bar"}
 
     cluster_with_mixin = MockCluster()
 

--- a/dask_cloudprovider/aws/tests/test_helper.py
+++ b/dask_cloudprovider/aws/tests/test_helper.py
@@ -40,3 +40,28 @@ def test_get_sleep_duration_negative_try():
         current_try=-1, min_sleep_millis=10, max_sleep_millis=5000
     )
     assert duration == 0.01
+
+
+def test_config_mixin():
+    from dask_cloudprovider.aws.helper import ConfigMixin
+
+    class MockCluster(ConfigMixin):
+        config = None
+        _attr1 = "foo"
+        attr2 = None
+
+        def __init__(self):
+            self.config = {
+                "attr2": "bar"
+            }
+
+    cluster_with_mixin = MockCluster()
+
+    # Test that nothing happens if attr is already set
+    attr1 = cluster_with_mixin._attr1
+    cluster_with_mixin.update_attr_from_config(attr="attr1", private=True)
+    assert cluster_with_mixin._attr1 == attr1
+
+    # Test that attr is updated if existing value is None
+    cluster_with_mixin.update_attr_from_config(attr="attr2", private=False)
+    assert cluster_with_mixin.attr2 == "bar"

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -2,6 +2,7 @@ cloudprovider:
   ecs:
     fargate_scheduler: False # Use fargate mode for the scheduler
     fargate_workers: False # Use fargate mode for the workers
+    fargate_use_private_ip: False
     scheduler_cpu: 1024 # Millicpu (1024ths of a CPU core)
     scheduler_mem: 4096 # Memory in MB
     #   scheduler_extra_args: "--tls-cert,/path/to/cert.pem,--tls-key,/path/to/cert.key,--tls-ca-file,/path/to/ca.key"

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -1,8 +1,9 @@
 cloudprovider:
   ecs:
-    fargate_scheduler: False # Use fargate mode for the scheduler
-    fargate_workers: False # Use fargate mode for the workers
-    fargate_use_private_ip: False
+    fargate_scheduler: false # Use fargate mode for the scheduler
+    fargate_spot: false
+    fargate_workers: false # Use fargate mode for the workers
+    fargate_use_private_ip: false
     scheduler_cpu: 1024 # Millicpu (1024ths of a CPU core)
     scheduler_mem: 4096 # Memory in MB
     #   scheduler_extra_args: "--tls-cert,/path/to/cert.pem,--tls-key,/path/to/cert.key,--tls-ca-file,/path/to/ca.key"
@@ -33,7 +34,7 @@ cloudprovider:
     tags: {} # Tags to apply to all AWS resources created by the cluster manager
     environment: {} # Environment variables that are set within a task container
     find_address_timeout: 60 # Configurable timeout in seconds for finding the task IP from the cloudwatch logs.
-    skip_cleanup: False # Skip cleaning up of stale resources
+    skip_cleanup: false # Skip cleaning up of stale resources
 
   ec2:
     region: null # AWS region to create cluster. Defaults to environment or account default region.


### PR DESCRIPTION
This PR adds `fargate_use_private_ip` to `cloudprovider.yaml`, which allows us to set defaults using dask config without passing a value to the `FargateCluster` constructor explicitly.

While making this update, I noticed that there is a lot of duplicated logic in `ECSCluster._start()`, specifically with how class attributes are set/updated. I cleaned this up by creating a helper function. This helper function is implemented as a mixin, as it would be nice to also use it in `EC2Cluster`. However, the corresponding logic there is a bit different. Namely, arguments from the constructor are not saved to the instance, and the config update happens in the constructor (as opposed to `_start`). So I decided not to include that in this PR, but I would be happy to refactor to use this mixin if you're ok with it @jacobtomlinson.