### PR TITLE
Option to Provide Task Definition ARNs to ECSCluster

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -722,6 +722,10 @@ class ECSCluster(SpecCluster, ConfigMixin):
         task_role_policies=None,
         cloudwatch_logs_group=None,
         cloudwatch_logs_stream_prefix=None,
+        scheduler_logs_group=None,
+        scheduler_logs_prefix=None,
+        worker_logs_group=None,
+        worker_logs_prefix=None,
         cloudwatch_logs_default_retention=None,
         vpc=None,
         subnets=None,
@@ -771,8 +775,35 @@ class ECSCluster(SpecCluster, ConfigMixin):
         self._execution_role_arn = execution_role_arn
         self._task_role_arn = task_role_arn
         self._task_role_policies = task_role_policies
-        self.cloudwatch_logs_group = cloudwatch_logs_group
-        self._cloudwatch_logs_stream_prefix = cloudwatch_logs_stream_prefix
+
+        if (scheduler_logs_group is None) != (scheduler_logs_prefix is None) or (
+            worker_logs_group is None
+        ) != (worker_logs_prefix is None):
+            raise ValueError(
+                "When overriding the scheduler / worker log group / prefix, both the group and the prefix must be "
+                "provided."
+            )
+
+        self.scheduler_logs_group = (
+            scheduler_logs_group
+            if scheduler_logs_group is not None
+            else cloudwatch_logs_group,
+        )
+        self._scheduler_logs_prefix = (
+            scheduler_logs_prefix
+            if scheduler_logs_prefix is not None
+            else cloudwatch_logs_stream_prefix
+        )
+        self.worker_logs_group = (
+            worker_logs_group
+            if worker_logs_group is not None
+            else cloudwatch_logs_group
+        )
+        self._worker_logs_prefix = (
+            worker_logs_prefix
+            if worker_logs_prefix is not None
+            else cloudwatch_logs_stream_prefix
+        )
         self._cloudwatch_logs_default_retention = cloudwatch_logs_default_retention
         self._vpc = vpc
         self._vpc_subnets = subnets
@@ -880,27 +911,72 @@ class ECSCluster(SpecCluster, ConfigMixin):
                 )["clusters"]
             self.cluster_name = cluster_info["clusterName"]
 
-        if self._execution_role_arn is None:
-            self._execution_role_arn = (
-                self.config.get("execution_role_arn")
-                or await self._create_execution_role()
+        if (
+            not self._scheduler_task_definition_arn_provided
+            and not self._worker_task_definition_arn_provided
+        ):
+            if self._execution_role_arn is None:
+                self._execution_role_arn = (
+                    self.config.get("execution_role_arn")
+                    or await self._create_execution_role()
+                )
+
+            if self._task_role_policies is None:
+                self._task_role_policies = self.config.get("task_role_policies")
+
+            if self._task_role_arn is None:
+                self._task_role_arn = (
+                    self.config.get("task_role_arn") or await self._create_task_role()
+                )
+
+        if self._cloudwatch_logs_default_retention is None:
+            self._cloudwatch_logs_default_retention = self.config.get(
+                "cloudwatch_logs_default_retention"
             )
 
-        if self._task_role_arn is None:
-            self._task_role_arn = (
-                self.config.get("task_role_arn") or await self._create_task_role()
-            )
+        if self._scheduler_logs_prefix is None or self.scheduler_logs_group is None:
+            if self._scheduler_task_definition_arn_provided:
+                log_options = await _get_log_properties_from_task_definition(
+                    self.scheduler_task_definition_arn,
+                    aws_access_key_id=self._aws_access_key_id,
+                    aws_secret_access_key=self._aws_secret_access_key,
+                    region_name=self._region_name,
+                )
+                self._scheduler_logs_prefix = log_options["awslogs-stream-prefix"]
+                self.scheduler_logs_group = log_options["awslogs-group"]
+            else:
+                if self._scheduler_logs_prefix is None:
+                    self._scheduler_logs_prefix = self.config.get(
+                        "cloudwatch_logs_stream_prefix"
+                    ).format(cluster_name=self.cluster_name)
 
-        if self._cloudwatch_logs_stream_prefix is None:
-            self._cloudwatch_logs_stream_prefix = self.config.get(
-                "cloudwatch_logs_stream_prefix"
-            ).format(cluster_name=self.cluster_name)
+                if self.scheduler_logs_group is None:
+                    self.scheduler_logs_group = (
+                        self.config.get("cloudwatch_logs_group")
+                        or await self._create_cloudwatch_logs_group()
+                    )
 
-        if self.cloudwatch_logs_group is None:
-            self.cloudwatch_logs_group = (
-                self.config.get("cloudwatch_logs_group")
-                or await self._create_cloudwatch_logs_group()
-            )
+        if self._worker_logs_prefix is None or self.worker_logs_group is None:
+            if self._worker_task_definition_arn_provided:
+                log_options = await _get_log_properties_from_task_definition(
+                    self.worker_task_definition_arn,
+                    aws_access_key_id=self._aws_access_key_id,
+                    aws_secret_access_key=self._aws_secret_access_key,
+                    region_name=self._region_name,
+                )
+                self._worker_logs_prefix = log_options["awslogs-stream-prefix"]
+                self.worker_logs_group = log_options["awslogs-group"]
+            else:
+                if self._worker_logs_prefix is None:
+                    self._worker_logs_prefix = self.config.get(
+                        "cloudwatch_logs_stream_prefix"
+                    ).format(cluster_name=self.cluster_name)
+
+                if self.worker_logs_group is None:
+                    self.worker_logs_group = (
+                        self.config.get("cloudwatch_logs_group")
+                        or await self._create_cloudwatch_logs_group()
+                    )
 
         if self._vpc == "default":
             async with self._client("ec2") as client:
@@ -932,8 +1008,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
             "cluster_arn": self.cluster_arn,
             "vpc_subnets": self._vpc_subnets,
             "security_groups": self._security_groups,
-            "log_group": self.cloudwatch_logs_group,
-            "log_stream_prefix": self._cloudwatch_logs_stream_prefix,
             "environment": self._environment,
             "tags": self.tags,
             "platform_version": self._platform_version,
@@ -953,6 +1027,8 @@ class ECSCluster(SpecCluster, ConfigMixin):
             "task_definition_arn": self.worker_task_definition_arn,
             "fargate": self._fargate_workers,
             "fargate_capacity_provider": "FARGATE_SPOT" if self._fargate_spot else None,
+            "log_group": self.worker_logs_group,
+            "log_stream_prefix": self._worker_logs_prefix,
             "cpu": self._worker_cpu,
             "nthreads": self._worker_nthreads,
             "mem": self._worker_mem,
@@ -1190,8 +1266,8 @@ class ECSCluster(SpecCluster, ConfigMixin):
                             "logDriver": "awslogs",
                             "options": {
                                 "awslogs-region": ecs.meta.region_name,
-                                "awslogs-group": self.cloudwatch_logs_group,
-                                "awslogs-stream-prefix": self._cloudwatch_logs_stream_prefix,
+                                "awslogs-group": self.scheduler_logs_group,
+                                "awslogs-stream-prefix": self._scheduler_logs_prefix,
                                 "awslogs-create-group": "true",
                             },
                         },
@@ -1268,8 +1344,8 @@ class ECSCluster(SpecCluster, ConfigMixin):
                             "logDriver": "awslogs",
                             "options": {
                                 "awslogs-region": ecs.meta.region_name,
-                                "awslogs-group": self.cloudwatch_logs_group,
-                                "awslogs-stream-prefix": self._cloudwatch_logs_stream_prefix,
+                                "awslogs-group": self.worker_logs_group,
+                                "awslogs-stream-prefix": self._worker_logs_prefix,
                                 "awslogs-create-group": "true",
                             },
                         },
@@ -1575,3 +1651,28 @@ async def _cleanup_stale_resources(**kwargs):
                                 RoleName=role["RoleName"], PolicyArn=policy["PolicyArn"]
                             )
                         await iam.delete_role(RoleName=role["RoleName"])
+
+
+async def _get_log_properties_from_task_definition(task_definition_arn, **kwargs):
+    session = get_session()
+    async with session.create_client("ecs", **kwargs) as ecs:
+        response = await ecs.describe_task_definition(
+            taskDefinition=task_definition_arn, include=["TAGS"]
+        )
+        log_configs = [
+            c["logConfiguration"]["options"]
+            for c in response["taskDefinition"]["containerDefinitions"]
+            if "logConfiguration" in c
+            and c["logConfiguration"]["logDriver"] == "awslogs"
+        ]
+
+        if len(log_configs) == 1:
+            log_config = log_configs[0]
+            if log_config["awslogs-region"] != ecs.meta.region_name:
+                raise ValueError(
+                    "the log group for the scheduler / worker must be in the same region"
+                    "as the task running the cluster"
+                )
+            return log_config
+        else:
+            raise ValueError("cannot determine what log configuration to use")

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -367,10 +367,18 @@ class Scheduler(Task):
     See :class:`Task` for parameter info.
     """
 
-    def __init__(self, port, **kwargs):
+    def __init__(self, scheduler_timeout, scheduler_extra_args=None, **kwargs):
         super().__init__(**kwargs)
         self.port = port
         self.task_type = "scheduler"
+        self._overrides = {
+            "command": [
+                "dask-scheduler",
+                "--idle-timeout",
+                scheduler_timeout,
+            ]
+            + (list() if not scheduler_extra_args else scheduler_extra_args)
+        }
 
     @property
     def address(self):
@@ -937,6 +945,8 @@ class ECSCluster(SpecCluster, ConfigMixin):
             "fargate_capacity_provider": "FARGATE" if self._fargate_spot else None,
             "port": self._scheduler_port,
             "task_kwargs": self._scheduler_task_kwargs,
+            "scheduler_timeout": self._scheduler_timeout,
+            "scheduler_extra_args": self._scheduler_extra_args,
             **options,
         }
         worker_options = {

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -495,6 +495,11 @@ class ECSCluster(SpecCluster, ConfigMixin):
         The arn of the task definition that the cluster should use to start the scheduler task. If provided, this will
         override the `image`, `scheduler_cpu`, `scheduler_mem`, any role settings, any networking / VPC settings, as
         these are all part of the task definition.
+        
+        If this is provided, the log configuration (cloudwatch_logs_group / cloudwatch_logs_stream_prefix /
+        scheduler_logs_group / scheduler_logs_prefix) must match the actual task definition logging configuration
+        so that dask-cloudprovider can detect using the logs when the task has launched. However, if no logging
+        configuration is provided, dask-cloudprovider will read the logging configuration from the task definition.
 
         Defaults to `None`, meaning that the task definition will be created along with the cluster, and cleaned up once
         the cluster is shut down.
@@ -530,6 +535,11 @@ class ECSCluster(SpecCluster, ConfigMixin):
         The arn of the task definition that the cluster should use to start the worker tasks. If provided, this will
         override the `image`, `worker_cpu`, `worker_mem`, any role settings, any networking / VPC settings, as
         these are all part of the task definition.
+
+        If this is provided, the log configuration (cloudwatch_logs_group / cloudwatch_logs_stream_prefix /
+        worker_logs_group / worker_logs_prefix) must match the actual task definition logging configuration
+        so that dask-cloudprovider can detect using the logs when the task has launched. However, if no logging
+        configuration is provided, dask-cloudprovider will read the logging configuration from the task definition.
 
         Defaults to `None`, meaning that the task definition will be created along with the cluster, and cleaned up once
         the cluster is shut down.
@@ -601,6 +611,8 @@ class ECSCluster(SpecCluster, ConfigMixin):
         Default ``None`` (no policies will be attached to the role)
     cloudwatch_logs_group: str (optional)
         The name of an existing cloudwatch log group to place logs into.
+        Can be overridden separately for the scheduler / worker using the
+        scheduler_logs_group / worker_logs_group arguments.
 
         Default ``None`` (one will be created called ``dask-ecs``)
     cloudwatch_logs_stream_prefix: str (optional)
@@ -611,6 +623,26 @@ class ECSCluster(SpecCluster, ConfigMixin):
         Retention for logs in days. For use when log group is auto created.
 
         Defaults to ``30``.
+    scheduler_logs_group: str (optional)
+        The name of an existing cloudwatch log group to place scheduler logs into.
+        If provided, scheduler_logs_prefix must be also provided.
+
+        Defaults to ``None`` (the value of cloudwatch_logs_group will be used)
+    scheduler_logs_prefix: str (optional)
+        Prefix for the scheduler log streams.
+        If provided, scheduler_logs_group must be also provided.
+
+        Defaults to ``None`` (the value of cloudwatch_logs_stream_prefix will be used)
+    worker_logs_group: str (optional)
+        The name of an existing cloudwatch log group to place scheduler logs into.
+        If provided, worker_logs_prefix must be also provided.
+
+        Defaults to ``None`` (the value of cloudwatch_logs_group will be used)
+    worker_logs_prefix: str (optional)
+        Prefix for the scheduler log streams.
+        If provided, worker_logs_group must be also provided.
+
+        Defaults to ``None`` (the value of cloudwatch_logs_stream_prefix will be used)
     vpc: str (optional)
         The ID of the VPC you wish to launch your cluster in.
 

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -360,14 +360,19 @@ class Scheduler(Task):
         Note: If the task is launched with a default configuration, the internal and
         external port will be the same. Otherwise it is the caller's responsibility to
         set up the task such that the scheduler is reachable on this port.
+    scheduler_timeout: str
+        Time of inactivity after which to kill the scheduler.
+    scheduler_extra_args: List[str] (optional)
+        Any extra command line arguments to pass to dask-scheduler, e.g. ``["--tls-cert", "/path/to/cert.pem"]``
 
+        Defaults to `None`, no extra command line arguments.
     kwargs: Dict()
         Other kwargs to be passed to :class:`Task`.
 
     See :class:`Task` for parameter info.
     """
 
-    def __init__(self, scheduler_timeout, scheduler_extra_args=None, **kwargs):
+    def __init__(self, port, scheduler_timeout, scheduler_extra_args=None, **kwargs):
         super().__init__(**kwargs)
         self.port = port
         self.task_type = "scheduler"

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -495,7 +495,7 @@ class ECSCluster(SpecCluster, ConfigMixin):
         The arn of the task definition that the cluster should use to start the scheduler task. If provided, this will
         override the `image`, `scheduler_cpu`, `scheduler_mem`, any role settings, any networking / VPC settings, as
         these are all part of the task definition.
-        
+
         If this is provided, the log configuration (cloudwatch_logs_group / cloudwatch_logs_stream_prefix /
         scheduler_logs_group / scheduler_logs_prefix) must match the actual task definition logging configuration
         so that dask-cloudprovider can detect using the logs when the task has launched. However, if no logging

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -754,7 +754,7 @@ class ECSCluster(SpecCluster, ConfigMixin):
         self._scheduler_extra_args = scheduler_extra_args
         self.scheduler_task_definition_arn = scheduler_task_definition_arn
         self._scheduler_task_definition_arn_provided = (
-            scheduler_task_definition_arn != None
+            scheduler_task_definition_arn is not None
         )
         self._scheduler_task_kwargs = scheduler_task_kwargs
         self._scheduler_address = scheduler_address
@@ -763,7 +763,9 @@ class ECSCluster(SpecCluster, ConfigMixin):
         self._worker_mem = worker_mem
         self._worker_gpu = worker_gpu
         self.worker_task_definition_arn = worker_task_definition_arn
-        self._worker_task_definition_arn_provided = worker_task_definition_arn != None
+        self._worker_task_definition_arn_provided = (
+            worker_task_definition_arn is not None
+        )
         self._worker_extra_args = worker_extra_args
         self._worker_task_kwargs = worker_task_kwargs
         self._n_workers = n_workers

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -496,11 +496,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
         override the `image`, `scheduler_cpu`, `scheduler_mem`, any role settings, any networking / VPC settings, as
         these are all part of the task definition.
 
-        If this is provided, the log configuration (cloudwatch_logs_group / cloudwatch_logs_stream_prefix /
-        scheduler_logs_group / scheduler_logs_prefix) must match the actual task definition logging configuration
-        so that dask-cloudprovider can detect using the logs when the task has launched. However, if no logging
-        configuration is provided, dask-cloudprovider will read the logging configuration from the task definition.
-
         Defaults to `None`, meaning that the task definition will be created along with the cluster, and cleaned up once
         the cluster is shut down.
     scheduler_task_kwargs: dict (optional)
@@ -535,11 +530,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
         The arn of the task definition that the cluster should use to start the worker tasks. If provided, this will
         override the `image`, `worker_cpu`, `worker_mem`, any role settings, any networking / VPC settings, as
         these are all part of the task definition.
-
-        If this is provided, the log configuration (cloudwatch_logs_group / cloudwatch_logs_stream_prefix /
-        worker_logs_group / worker_logs_prefix) must match the actual task definition logging configuration
-        so that dask-cloudprovider can detect using the logs when the task has launched. However, if no logging
-        configuration is provided, dask-cloudprovider will read the logging configuration from the task definition.
 
         Defaults to `None`, meaning that the task definition will be created along with the cluster, and cleaned up once
         the cluster is shut down.
@@ -611,8 +601,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
         Default ``None`` (no policies will be attached to the role)
     cloudwatch_logs_group: str (optional)
         The name of an existing cloudwatch log group to place logs into.
-        Can be overridden separately for the scheduler / worker using the
-        scheduler_logs_group / worker_logs_group arguments.
 
         Default ``None`` (one will be created called ``dask-ecs``)
     cloudwatch_logs_stream_prefix: str (optional)
@@ -623,26 +611,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
         Retention for logs in days. For use when log group is auto created.
 
         Defaults to ``30``.
-    scheduler_logs_group: str (optional)
-        The name of an existing cloudwatch log group to place scheduler logs into.
-        If provided, scheduler_logs_prefix must be also provided.
-
-        Defaults to ``None`` (the value of cloudwatch_logs_group will be used)
-    scheduler_logs_prefix: str (optional)
-        Prefix for the scheduler log streams.
-        If provided, scheduler_logs_group must be also provided.
-
-        Defaults to ``None`` (the value of cloudwatch_logs_stream_prefix will be used)
-    worker_logs_group: str (optional)
-        The name of an existing cloudwatch log group to place scheduler logs into.
-        If provided, worker_logs_prefix must be also provided.
-
-        Defaults to ``None`` (the value of cloudwatch_logs_group will be used)
-    worker_logs_prefix: str (optional)
-        Prefix for the scheduler log streams.
-        If provided, worker_logs_group must be also provided.
-
-        Defaults to ``None`` (the value of cloudwatch_logs_stream_prefix will be used)
     vpc: str (optional)
         The ID of the VPC you wish to launch your cluster in.
 


### PR DESCRIPTION
Aims to resolve #135.

This set of changes provides an option to provide task definitions to the `ECSCluster` rather than having the cluster create one on startup. This can help with the proliferation of task definition families on the AWS UI, and with providing various settings to the task definition that the cluster doesn't support directly.
