### PR TITLE
add status when passing existing scheduler to ECS

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1004,6 +1004,7 @@ class ECSCluster(SpecCluster):
             class SchedulerAddress(object):
                 def __init__(self_):
                     self_.address = self._scheduler_address
+                    self_.status = Status.running
 
                 def __await__(self):
                     async def _():


### PR DESCRIPTION
This fixes #360 : `scale` function in distributed looks for a status attribute. When passing an existing scheduler to ECSCluster we assume it is already running, and so return this status.

I replicated the issue on my account, then applied the change and saw that `scale` worked ok.

It might be more appropriate to update distributed to not depend on both the scheduler object as passed, as well as on rpc communication. Since the rpc is required anyway, it could be used to get the scheduler status (`scheduler_comm.status`), reducing the need for two sources of truth, but increasing communication (though without the communication no answer is correct)

Also note that `scale_down` has more interesting requirements, and can't be made to work easily.