### PR TITLE
Ability to enable detailed monitoring for EC2 instances

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -55,7 +55,7 @@ class EC2Instance(VMInterface):
         instance_tags: None,
         volume_tags: None,
         use_private_ip: False,
-        enable_detailed_monitoring: False,
+        enable_detailed_monitoring=False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -361,7 +361,7 @@ class EC2Cluster(VMCluster):
     enable_detailed_monitoring: bool (optional)
         Whether to enable detailed monitoring for created instances.
         See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
-        Default ``False``.
+        Default ``None``.
 
     Notes
     -----
@@ -470,7 +470,7 @@ class EC2Cluster(VMCluster):
         instance_tags=None,
         volume_tags=None,
         use_private_ip=False,
-        enable_detailed_monitoring=False,
+        enable_detailed_monitoring=None,
         **kwargs,
     ):
         self.boto_session = get_session()
@@ -531,7 +531,11 @@ class EC2Cluster(VMCluster):
 
         self._use_private_ip = use_private_ip
 
-        self.enable_detailed_monitoring = enable_detailed_monitoring
+        self.enable_detailed_monitoring = (
+            enable_detailed_monitoring
+            if enable_detailed_monitoring is not None
+            else self.config.get("enable_detailed_monitoring")
+        )
 
         self.options = {
             "cluster": self,

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -55,6 +55,7 @@ class EC2Instance(VMInterface):
         instance_tags: None,
         volume_tags: None,
         use_private_ip: False,
+        enable_detailed_monitoring: False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -79,6 +80,7 @@ class EC2Instance(VMInterface):
         self.instance_tags = instance_tags
         self.volume_tags = volume_tags
         self.use_private_ip = use_private_ip
+        self.enable_detailed_monitoring = enable_detailed_monitoring
 
     async def create_vm(self):
         """
@@ -121,7 +123,7 @@ class EC2Instance(VMInterface):
                 "InstanceType": self.instance_type,
                 "MaxCount": 1,
                 "MinCount": 1,
-                "Monitoring": {"Enabled": False},
+                "Monitoring": {"Enabled": self.enable_detailed_monitoring},
                 "UserData": self.cluster.render_process_cloud_init(self),
                 "InstanceInitiatedShutdownBehavior": "terminate",
                 "NetworkInterfaces": [
@@ -356,6 +358,10 @@ class EC2Cluster(VMCluster):
         Whether to use a private IP (if True) or public IP (if False).
 
         Default ``False``.
+    enable_detailed_monitoring: bool (optional)
+        Whether to enable detailed monitoring for created instances.
+        See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
+        Default ``False``.
 
     Notes
     -----
@@ -464,6 +470,7 @@ class EC2Cluster(VMCluster):
         instance_tags=None,
         volume_tags=None,
         use_private_ip=False,
+        enable_detailed_monitoring=False,
         **kwargs,
     ):
         self.boto_session = get_session()
@@ -524,6 +531,8 @@ class EC2Cluster(VMCluster):
 
         self._use_private_ip = use_private_ip
 
+        self.enable_detailed_monitoring = enable_detailed_monitoring
+
         self.options = {
             "cluster": self,
             "config": self.config,
@@ -543,6 +552,7 @@ class EC2Cluster(VMCluster):
             "instance_tags": self.instance_tags,
             "volume_tags": self.volume_tags,
             "use_private_ip": self._use_private_ip,
+            "enable_detailed_monitoring": self.enable_detailed_monitoring,
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -55,7 +55,7 @@ class EC2Instance(VMInterface):
         instance_tags: None,
         volume_tags: None,
         use_private_ip: False,
-        enable_detailed_monitoring=False,
+        enable_detailed_monitoring=None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -361,7 +361,7 @@ class EC2Cluster(VMCluster):
     enable_detailed_monitoring: bool (optional)
         Whether to enable detailed monitoring for created instances.
         See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html
-        Default ``None``.
+        Default ``False``.
 
     Notes
     -----

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -55,6 +55,7 @@ cloudprovider:
       createdBy: dask-cloudprovider
     volume_tags:
       createdBy: dask-cloudprovider
+    enable_detailed_monitoring: false
 
   azure:
     location: null # The Azure location to launch your cluster


### PR DESCRIPTION
As title. See [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) for documentation on detailed vs. basic monitoring.