### PR TITLE
EC2Cluster support for different instance types on scheduler and workers

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -516,7 +516,7 @@ class EC2Cluster(VMCluster):
             if instance_type is not None
             else self.config.get("instance_type")
         )
-        if self.instance_type is None:
+        if instance_type is None:
             self.scheduler_instance_type = (
                 scheduler_instance_type
                 if scheduler_instance_type is not None

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -533,7 +533,8 @@ class EC2Cluster(VMCluster):
                     "If you specify instance_type, you may not specify scheduler_instance_type or worker_instance_type"
                 )
             warnings.warn(
-                "The instance_type argument will be deprecated in a future version. Please use scheduler_instance_type and worker_instance_type instead",
+                "The instance_type argument will be deprecated in a future version. Please use scheduler_instance_type"
+                "and worker_instance_type instead",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import warnings
 
 import dask
 from dask_cloudprovider.generic.vmcluster import (
@@ -278,7 +279,23 @@ class EC2Cluster(VMCluster):
         If the instance_type is a GPU instance the NVIDIA drivers and Docker GPU runtime will be installed
         at runtime.
     instance_type: string (optional)
-        A valid EC2 instance type. This will determine the resources available to your workers.
+        A valid EC2 instance type. This will determine the resources available to the scheduler and all workers.
+
+        **Note:** this will be deprecated in a future release. Please use ``scheduler_instance_type`` and
+        ``worker_instance_type`` instead. If supplied, you may not specify ``scheduler_instance_type`` or
+        ``worker_instance_type``
+
+        See https://aws.amazon.com/ec2/instance-types/.
+
+        By default will use ``t2.micro``.
+    scheduler_instance_type: string (optional)
+        A valid EC2 instance type.  This will determine the resources available to the scheduler.
+
+        See https://aws.amazon.com/ec2/instance-types/.
+
+        By default will use ``t2.micro``.
+    worker_instance_type: string (optional)
+        A valid EC2 instance type.  This will determine the resources available to all workers.
 
         See https://aws.amazon.com/ec2/instance-types/.
 
@@ -459,6 +476,8 @@ class EC2Cluster(VMCluster):
         auto_shutdown=None,
         ami=None,
         instance_type=None,
+        scheduler_instance_type=None,
+        worker_instance_type=None,
         vpc=None,
         subnet_id=None,
         security_groups=None,
@@ -497,6 +516,30 @@ class EC2Cluster(VMCluster):
             if instance_type is not None
             else self.config.get("instance_type")
         )
+        if self.instance_type is None:
+            self.scheduler_instance_type = (
+                scheduler_instance_type
+                if scheduler_instance_type is not None
+                else self.config.get("scheduler_instance_type")
+            )
+            self.worker_instance_type = (
+                worker_instance_type
+                if worker_instance_type is not None
+                else self.config.get("worker_instance_type")
+            )
+        else:
+            if scheduler_instance_type is not None or worker_instance_type is not None:
+                raise ValueError(
+                    "If you specify instance_type, you may not specify scheduler_instance_type or worker_instance_type"
+                )
+            warnings.warn(
+                "The instance_type argument will be deprecated in a future version. Please use scheduler_instance_type and worker_instance_type instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.scheduler_instance_type = instance_type
+            self.worker_instance_type = instance_type
+
         self.gpu_instance = self.instance_type.startswith(("p", "g"))
         self.vpc = vpc if vpc is not None else self.config.get("vpc")
         self.subnet_id = (
@@ -546,6 +589,8 @@ class EC2Cluster(VMCluster):
             "ami": self.ami,
             "docker_image": docker_image or self.config.get("docker_image"),
             "instance_type": self.instance_type,
+            "scheduler_instance_type": self.scheduler_instance_type,
+            "worker_instance_type": self.worker_instance_type,
             "gpu_instance": self.gpu_instance,
             "vpc": self.vpc,
             "subnet_id": self.subnet_id,
@@ -560,4 +605,6 @@ class EC2Cluster(VMCluster):
         }
         self.scheduler_options = {**self.options}
         self.worker_options = {**self.options}
+        self.scheduler_options["instance_type"] = self.scheduler_instance_type
+        self.worker_options["instance_type"] = self.worker_instance_type
         super().__init__(debug=debug, **kwargs)

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -1,6 +1,5 @@
 import asyncio
 import random
-import warnings
 
 import dask
 from dask_cloudprovider.generic.vmcluster import (
@@ -280,10 +279,7 @@ class EC2Cluster(VMCluster):
         at runtime.
     instance_type: string (optional)
         A valid EC2 instance type. This will determine the resources available to the scheduler and all workers.
-
-        **Note:** this will be deprecated in a future release. Please use ``scheduler_instance_type`` and
-        ``worker_instance_type`` instead. If supplied, you may not specify ``scheduler_instance_type`` or
-        ``worker_instance_type``
+        If supplied, you may not specify ``scheduler_instance_type`` or ``worker_instance_type``.
 
         See https://aws.amazon.com/ec2/instance-types/.
 
@@ -532,12 +528,6 @@ class EC2Cluster(VMCluster):
                 raise ValueError(
                     "If you specify instance_type, you may not specify scheduler_instance_type or worker_instance_type"
                 )
-            warnings.warn(
-                "The instance_type argument will be deprecated in a future version. Please use scheduler_instance_type"
-                "and worker_instance_type instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             self.scheduler_instance_type = instance_type
             self.worker_instance_type = instance_type
 

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -43,7 +43,7 @@ cloudprovider:
     auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.
     # worker_command: "dask-worker" # The command for workers to run. If the instance_type is a GPU instance dask-cuda-worker will be used.
     # ami: "" # AMI ID to use for all instances. Defaults to latest Ubuntu 20.04 image.
-    instance_type: "t2.micro" # [Will be deprecated in future release] Instance type for the scheduler and all workers
+    instance_type: "t2.micro" # Instance type for the scheduler and all workers
     scheduler_instance_type: "t2.micro" # Instance type for the scheduler
     worker_instance_type: "t2.micro" # Instance type for all workers
     docker_image: "daskdev/dask:latest" # docker image to use

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -43,7 +43,9 @@ cloudprovider:
     auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.
     # worker_command: "dask-worker" # The command for workers to run. If the instance_type is a GPU instance dask-cuda-worker will be used.
     # ami: "" # AMI ID to use for all instances. Defaults to latest Ubuntu 20.04 image.
-    instance_type: "t2.micro" # Instance type for all workers
+    instance_type: "t2.micro" # [Will be deprecated in future release] Instance type for the scheduler and all workers
+    scheduler_instance_type: "t2.micro" # Instance type for the scheduler
+    worker_instance_type: "t2.micro" # Instance type for all workers
     docker_image: "daskdev/dask:latest" # docker image to use
     # vpc: "" # VPC id for instances to join. Defaults to default VPC.
     # subnet_id: "" # Subnet ID for instances to. Defaults to all subnets in default VPC.


### PR DESCRIPTION
`FargateCluster` supports different instance types for the scheduler and workers (via the `scheduler_mem`, `scheduler_cpu`, `worker_mem`, `worker_cpu` arguments), but `EC2Cluster` does not provide this flexibility. This PR changes this by introducing two new arguments to `EC2Cluster`: `scheduler_instance_type` and `worker_instance_type`. 

I believe this flexibility gives a better experience, and it also establishes consistency with `FargateCluster`. For these reasons I propose deprecating `instance_type` in favor of the new args above. This PR was written with this deprecation in mind, however I did not want to introduce a breaking change. Thus my solution is to raise a deprecation warning when users supply the `instance_type` argument, and in this case both the scheduler and workers share that type (as they currently do). However, an error is raised if users supply `instance_type` _and_ one of the new arguments. Default values are not changed, so users who don't pass in any of these args will see no change.

I'm open to feedback on my assumptions above. Hopefully I didn't come in too strong with a deprecation without opening an issue first 🙃 