### PR TITLE
use gp3 by default for AWS EBS storage

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -114,7 +114,7 @@ class EC2Instance(VMInterface):
                         "Ebs": {
                             "DeleteOnTermination": True,
                             "VolumeSize": self.filesystem_size,
-                            "VolumeType": "gp2",
+                            "VolumeType": "gp3",
                             "Encrypted": False,
                         },
                     }


### PR DESCRIPTION
gp3 is cheaper and more performant than gp2
https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/