### PR TITLE
Enable all EC2 config options in `cloudprovider.yaml`

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -484,7 +484,7 @@ class EC2Cluster(VMCluster):
         debug=False,
         instance_tags=None,
         volume_tags=None,
-        use_private_ip=False,
+        use_private_ip=None,
         enable_detailed_monitoring=None,
         **kwargs,
     ):
@@ -563,7 +563,11 @@ class EC2Cluster(VMCluster):
         volume_tags = volume_tags if volume_tags is not None else {}
         self.volume_tags = {**volume_tags, **self.config.get("volume_tags")}
 
-        self._use_private_ip = use_private_ip
+        self._use_private_ip = (
+            use_private_ip
+            if use_private_ip is not None
+            else self.config.get("use_private_ip")
+        )
 
         self.enable_detailed_monitoring = (
             enable_detailed_monitoring

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -42,14 +42,14 @@ cloudprovider:
     bootstrap: true # It is assumed that the AMI does not have Docker and needs bootstrapping. Set this to false if using a custom AMI with Docker already installed.
     auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.
     # worker_command: "dask-worker" # The command for workers to run. If the instance_type is a GPU instance dask-cuda-worker will be used.
-    # ami: "" # AMI ID to use for all instances. Defaults to latest Ubuntu 20.04 image.
+    ami: null # AMI ID to use for all instances. Defaults to latest Ubuntu 20.04 image.
     instance_type: "t2.micro" # Instance type for the scheduler and all workers
     scheduler_instance_type: "t2.micro" # Instance type for the scheduler
     worker_instance_type: "t2.micro" # Instance type for all workers
     docker_image: "daskdev/dask:latest" # docker image to use
-    # vpc: "" # VPC id for instances to join. Defaults to default VPC.
-    # subnet_id: "" # Subnet ID for instances to. Defaults to all subnets in default VPC.
-    # security_groups: [] # Security groups for instances. Will create a minimal Dask security group by default.
+    vpc: null # VPC id for instances to join. Defaults to default VPC.
+    subnet_id: null # Subnet ID for instances to. Defaults to all subnets in default VPC.
+    security_groups: [] # Security groups for instances. Will create a minimal Dask security group by default.
     filesystem_size: 40 # Default root filesystem size for scheduler and worker VMs in GB
     key_name: null # SSH Key name to assign to instances
     iam_instance_profile: {} # Iam role to assign to instances
@@ -60,6 +60,7 @@ cloudprovider:
     volume_tags:
       createdBy: dask-cloudprovider
     enable_detailed_monitoring: false
+    use_private_ip: false
 
   azure:
     location: null # The Azure location to launch your cluster


### PR DESCRIPTION
This PR makes 2 updates with the goal of enabling more configuration to be done "behind the scenes" rather than supplied explicitly to the `EC2Cluster` constructor.

1. Fixes a bug (introduced in #353) where `EC2Cluster` constructor argument `use_private_ip` had incorrect default value, preventing intended behavior w.r.t loading from `cloudprovider.yaml` default. This argument was not actually in `cloudprovider.yaml` before, so this PR adds it as well.
2.  Uncomment  `ami`, `vpc`, `subnet_id` and `security_groups` from `cloudprovider.yaml` EC2 config. To test my change, I ran the following snippet and verified that the created cluster had the correct ami; was in the VPC, subnet, and security_groups specified in my config, and used private IP address.

```
import dask
from dask_cloudprovider.aws import EC2Cluster

my_dask_config = {
    "cloudprovider": {
        "ec2": {
            "security_groups": ["my-security-group-id"],
            "subnet_id": "my-subnet-id",
            "use_private_ip": True,
            "vpc": "my-vpc-id",
        },
    },
}

dask.config.update(dask.config.config, my_dask_config)

ec2_cluster = EC2Cluster(
    security=False, # https://github.com/dask/dask-cloudprovider/issues/249,
    n_workers=2
)
```