### PR TITLE
Avoid deprecated method to get Azure subscription ID

### DIFF
--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -485,9 +485,13 @@ class AzureVMCluster(VMCluster):
         self.public_ingress = self.config.get(
             "azurevm.public_ingress", override_with=public_ingress
         )
-        if subscription_id is None:
-            subscription_id = _get_default_subscription()
-        self.subscription_id = self.config.get("subscription_id", override_with=subscription_id)
+        # We prefer code > Dask config > Azure CLI
+        self.subscription_id = self.config.get(
+            "subscription_id", override_with=subscription_id
+        )
+        if self.subscription_id is None:
+            self.subscription_id = _get_default_subscription()
+
         self.credentials = DefaultAzureCredential()
         self.compute_client = ComputeManagementClient(
             self.credentials, self.subscription_id

--- a/dask_cloudprovider/azure/tests/test_azurevm.py
+++ b/dask_cloudprovider/azure/tests/test_azurevm.py
@@ -1,4 +1,3 @@
-from dask_cloudprovider.azure.azurevm import AzureVM
 import pytest
 
 import dask
@@ -6,7 +5,6 @@ import dask
 azure_compute = pytest.importorskip("azure.mgmt.compute")
 
 from dask_cloudprovider.azure import AzureVMCluster
-from dask_cloudprovider.azure.utils import _get_default_subscription
 from dask.distributed import Client
 from distributed.core import Status
 

--- a/dask_cloudprovider/azure/tests/test_azurevm.py
+++ b/dask_cloudprovider/azure/tests/test_azurevm.py
@@ -1,28 +1,17 @@
+from dask_cloudprovider.azure.azurevm import AzureVM
 import pytest
 
 import dask
 
 azure_compute = pytest.importorskip("azure.mgmt.compute")
-from azure.common.credentials import get_azure_cli_credentials
 
 from dask_cloudprovider.azure import AzureVMCluster
+from dask_cloudprovider.azure.utils import _get_default_subscription
 from dask.distributed import Client
 from distributed.core import Status
 
 
 def skip_without_credentials(func):
-    try:
-        get_azure_cli_credentials()
-    except FileNotFoundError:
-        return pytest.mark.skip(
-            reason="""
-        You must configure your Azure credentials to run this test.
-
-            $ az login
-
-        """
-        )(func)
-
     rg = dask.config.get("cloudprovider.azure.resource_group", None)
     vnet = dask.config.get("cloudprovider.azure.azurevm.vnet", None)
     security_group = dask.config.get("cloudprovider.azure.azurevm.security_group", None)
@@ -33,9 +22,9 @@ def skip_without_credentials(func):
         You must configure your Azure resource group and vnet to run this test.
 
             $ export DASK_CLOUDPROVIDER__AZURE__LOCATION="<LOCATION>"
-            $ export DASK_CLOUDPROVIDER__AZURE__AZUREVM__RESOURCE_GROUP="<RESOURCE GROUP>"
+            $ export DASK_CLOUDPROVIDER__AZURE__RESOURCE_GROUP="<RESOURCE GROUP>"
             $ export DASK_CLOUDPROVIDER__AZURE__AZUREVM__VNET="<VNET>"
-            $ export DASK_CLOUDPROVIDER__AZURE__AZUREVM__SECURITY_GROUP="<SECUROTY GROUP>"
+            $ export DASK_CLOUDPROVIDER__AZURE__AZUREVM__SECURITY_GROUP="<SECURITY GROUP>"
 
         """
         )(func)

--- a/dask_cloudprovider/azure/utils.py
+++ b/dask_cloudprovider/azure/utils.py
@@ -1,5 +1,7 @@
 import asyncio
 import datetime
+import json
+import subprocess
 import logging
 
 import aiohttp
@@ -12,6 +14,21 @@ logger = logging.getLogger(__name__)
 AZURE_EVENTS_METADATA_URL = (
     "http://169.254.169.254/metadata/scheduledevents?api-version=2019-08-01"
 )
+
+
+def _get_default_subscription() -> str:
+    """
+    Get the default Azure subscription ID, as configured by the Azure CLI.
+    """
+    out = subprocess.check_output(["az", "account", "list", "--query", "[?isDefault]"])
+    accounts = json.loads(out)
+    if accounts:
+        subscription_id = accounts[0]["id"]
+        return subscription_id
+    raise ValueError(
+        "Could not find a default subscription. "
+        "Run 'az account set' to set a default subscription."
+    )
 
 
 class AzurePreemptibleWorkerPlugin(WorkerPlugin):

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -64,6 +64,7 @@ cloudprovider:
   azure:
     location: null # The Azure location to launch your cluster
     resource_group: null # The Azure resource group for the cluster
+    subscription_id: null # The Azure subscription ID for the cluster
     azurevm:
       vnet: null # Azure Virtual Network to launch VMs in
       security_group: null # Network security group to allow 8786 and 8787

--- a/doc/source/azure.rst
+++ b/doc/source/azure.rst
@@ -93,6 +93,32 @@ or specific IP.
 
 Again take note of this security group name for later.
 
+Dask Configuration
+^^^^^^^^^^^^^^^^^^
+
+You'll provide the names or IDs of the Azure resources when you create a :class:`AzureVMCluster`. You can specify
+these values manually, or use Dask's `configuration system <https://docs.dask.org/en/stable/configuration.html>`_
+system. For example, the ``resource_group`` value can be specified using an environment variable:
+
+.. code-block:: console
+
+   $ export DASK_CLOUDPROVIDER__AZURE__RESOURCE_GROUP="<resource group name>"
+   $ python
+
+Or you can set it in a YAML configuration file.
+
+.. code-block:: yaml
+
+   cloudprovider:
+     azure:
+       resource_group: "<resource group name>"
+       azurevm:
+        vnet: "<vnet name>"
+
+Note that the options controlling the VMs are under the `cloudprovider.azure.azurevm` key.
+
+See :doc:`config` for more.
+
 AzureVM
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,8 @@ import versioneer
 extras_require = {
     "aws": ["aiobotocore>=0.10.2"],
     "azure": [
-        "azure-mgmt-compute>=18.0.0,<19",
-        "azure-mgmt-network>=16.0.0,<17",
-        "azure-cli-core>=2.15.1,<2.21.0",
-        "msrestazure",
+        "azure-mgmt-compute>=18.0.0",
+        "azure-mgmt-network>=16.0.0",
         "azure-identity",
     ],
     "digitalocean": ["python-digitalocean>=1.15.0"],


### PR DESCRIPTION
This removes the use of a deprecated method from azure-cli-core to get the default subscription ID. It also removes the dependency on azure-cli-core.

For the common case, where the user has the Azure CLI installed and configured, we can get the subscription ID by parsing its output.

This PR also enables users to configure the subscription ID either in code or through the Dask config system.

A few related documentation updates for good measure.

FYI, I'm running the azure tests now. I'll let you know when they pass.

Closes https://github.com/dask/dask-cloudprovider/issues/376