### PR TITLE
Minimize aws permissions required for ecs/fargate cluster

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1343,7 +1343,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
                 "port."
             )
 
-
     async def _cleanup_stale_resources(self):
         """Clean up any stale resources which are tagged with 'createdBy': 'dask-cloudprovider'.
 

--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -42,8 +42,6 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
-
-
 class Task:
     """A superclass for managing ECS Tasks
     Parameters
@@ -1369,11 +1367,9 @@ class ECSCluster(SpecCluster, ConfigMixin):
         session = get_session()
         async with session.create_client("ecs", **aws_client_kwargs) as ecs:
             if self._cluster_arn_provided:
-                    # Can remove this permission if we parse the ARN instead
-                    cluster = await ecs.describe_clusters(
-                        clusters=self.cluster_arn
-                    )
-                    active_clusters = [cluster["clusterName"]]
+                # Can remove this permission if we parse the ARN instead
+                cluster = await ecs.describe_clusters(clusters=self.cluster_arn)
+                active_clusters = [cluster["clusterName"]]
             else:
                 # Clean up clusters (clusters with no running tasks)
                 active_clusters = await cleanup_stale_ecs_clusters(ecs)
@@ -1389,7 +1385,6 @@ class ECSCluster(SpecCluster, ConfigMixin):
         if not self._security_groups_provided:
             async with session.create_client("ec2", **aws_client_kwargs) as ec2:
                 await cleanup_stale_ec2_resources(ec2, active_clusters)
-
 
         # Clean up roles (with no active clusters)
         if not self._execution_role_arn_provided or not self._task_role_arn_provided:

--- a/dask_cloudprovider/aws/helper.py
+++ b/dask_cloudprovider/aws/helper.py
@@ -142,9 +142,7 @@ async def cleanup_stale_ecs_clusters(ecs_client):
             )
         )["clusters"]
         for cluster in clusters:
-            if set(DEFAULT_TAGS.items()) <= set(
-                aws_to_dict(cluster["tags"]).items()
-            ):
+            if set(DEFAULT_TAGS.items()) <= set(aws_to_dict(cluster["tags"]).items()):
                 if (
                     cluster["runningTasksCount"] == 0
                     and cluster["pendingTasksCount"] == 0


### PR DESCRIPTION
Intended to address https://github.com/dask/dask-cloudprovider/issues/381

### Overview
The goal is to reduce the number of AWS actions/permissions required to run the ECSCluster or FargateCluster. While one can pass `skip_cleanup=True` to avoid needing many permissions, sometimes one may want cleanup to happen on relevant resources. For example, if one always passes specific iam task roles when launching the cluster, there's no need for the cluster to try to clean up stale iam task roles. By only cleaning up resources that the cluster creates on its own, we can reduce the minimal permissions set.

### Changes
- Add conditional statements to only attempt to clean resources if resource arn's have not been provided for them
- Move the `_cleanup_stale_resources` to be a class method rather than a standalone function
- Break up `_cleanup_stale_resources` into helper functions for readability purposes

### Testing
I've not attempted to test this at all yet, so leaving this as a draft PR for now. But if you all are on board with this kind of approach, I will do some manual testing on my end.