### PR TITLE
ECS: Add Option to Specify TLS Scheduler

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import sched
 import uuid
 import warnings
 import weakref

--- a/dask_cloudprovider/cli/ecs.py
+++ b/dask_cloudprovider/cli/ecs.py
@@ -47,12 +47,6 @@ logger = logging.getLogger(__name__)
     help="The port on which the scheduler will be reachable to the workers and clients",
 )
 @click.option(
-    "--scheduler-tls",
-    type=bool,
-    default=False,
-    help="Whether workers and clients should attempt to connect to the scheduler via TLS",
-)
-@click.option(
     "--scheduler-timeout",
     type=int,
     default=None,
@@ -160,7 +154,6 @@ def main(
     scheduler_cpu,
     scheduler_mem,
     scheduler_port,
-    scheduler_tls,
     scheduler_timeout,
     worker_cpu,
     worker_mem,
@@ -196,7 +189,6 @@ def main(
             scheduler_cpu=scheduler_cpu,
             scheduler_mem=scheduler_mem,
             scheduler_port=scheduler_port,
-            scheduler_tls=scheduler_tls,
             scheduler_timeout=scheduler_timeout,
             worker_cpu=worker_cpu,
             worker_mem=worker_mem,

--- a/dask_cloudprovider/cli/ecs.py
+++ b/dask_cloudprovider/cli/ecs.py
@@ -47,6 +47,12 @@ logger = logging.getLogger(__name__)
     help="The port on which the scheduler will be reachable to the workers and clients",
 )
 @click.option(
+    "--scheduler-tls",
+    type=bool,
+    default=False,
+    help="Whether workers and clients should attempt to connect to the scheduler via TLS",
+)
+@click.option(
     "--scheduler-timeout",
     type=int,
     default=None,
@@ -154,6 +160,7 @@ def main(
     scheduler_cpu,
     scheduler_mem,
     scheduler_port,
+    scheduler_tls,
     scheduler_timeout,
     worker_cpu,
     worker_mem,
@@ -189,6 +196,7 @@ def main(
             scheduler_cpu=scheduler_cpu,
             scheduler_mem=scheduler_mem,
             scheduler_port=scheduler_port,
+            scheduler_tls=scheduler_tls,
             scheduler_timeout=scheduler_timeout,
             worker_cpu=worker_cpu,
             worker_mem=worker_mem,


### PR DESCRIPTION
Adds an option to specify that the scheduler is on TLS
Fixes #386