### PR TITLE
add new param to allow multiple workers in vmcluster, worker_mixin

### DIFF
--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -101,7 +101,7 @@ class WorkerMixin(object):
         worker_module: str = None,
         worker_class: str = None,
         worker_options: dict = {},
-	num_workers_per_vm: int = 1,
+        num_workers_per_vm: int = 1,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -124,7 +124,7 @@ class WorkerMixin(object):
             )
         if worker_class is not None:
             self.worker_class = worker_class
-	    self.num_workers_per_vm = num_workers_per_vm
+            self.num_workers_per_vm = num_workers_per_vm
             self.command = " ".join(
                 [
                     self.set_env,
@@ -135,15 +135,15 @@ class WorkerMixin(object):
                     "--spec",
                     "''%s''"  # in yaml double single quotes escape the single quote
                     % json.dumps(
-			{
-			    f"{i}": {
-				"cls": self.worker_class,
-				"opts": {
-				    **worker_options,
-				    "name": self.name,
-				},
-			    }
-			    for i in range(self.num_workers_per_vm)
+                        {
+                            f"{i}": {
+                                "cls": self.worker_class,
+                                "opts": {
+                                    **worker_options,
+                                    "name": self.name,
+                                },
+                            }
+                            for i in range(self.num_workers_per_vm)
                         }
                     ),
                 ]
@@ -229,7 +229,7 @@ class VMCluster(SpecCluster):
         n_workers: int = 0,
         worker_class: str = "dask.distributed.Nanny",
         worker_options: dict = {},
-	num_workers_per_vm: int = 1,
+        num_workers_per_vm: int = 1,
         scheduler_options: dict = {},
         docker_image="daskdev/dask:latest",
         docker_args: str = "",
@@ -295,7 +295,7 @@ class VMCluster(SpecCluster):
         self.worker_options["docker_args"] = docker_args
         self.worker_options["docker_image"] = image
         self.worker_options["worker_class"] = worker_class
-	self.worker_options["num_workers_per_vm"] = num_workers_per_vm
+        self.worker_options["num_workers_per_vm"] = num_workers_per_vm
         self.worker_options["protocol"] = protocol
         self.worker_options["worker_options"] = worker_options
         self.worker_options["extra_bootstrap"] = extra_bootstrap


### PR DESCRIPTION
Intended to address [#173](https://github.com/dask/dask-cloudprovider/issues/173)

**Overview**
The goal is to have the ability to spin up mulitple workers on VM Clusters (like `EC2Cluster`). 

- A new param `num_workers_per_vm` is added to the `VMCluster` and `WorkerMixin` classes. 
- This param defaults to 1 in both classes (this is the current behavior). 
- `num_workers_per_vm` worker classes are added to the spec (which are passed to `SpecCluster`) to initialize multiple workers.
- To keep changes minimal, there is no validation of this parameter to ensure `num_workers_per_vm` is less than number of cores available. 

**Testing**
Confirmed this works by creating an `EC2Cluster` as follows

```
ec2_cluster = EC2Cluster(
    env_vars=env_vars,
    extra_bootstrap=EC2_BOOTSTRAP_COMMANDS,
    filesystem_size=cluster_config["volume_size"],
    instance_tags=cluster_config["ec2_instance_tags"],
    n_workers=10,
    worker_class="distributed.nanny.Nanny",
    worker_options={"nthreads": 2, "memory_limit": "7GiB"},
    num_workers_per_vm=4,
    scheduler_instance_type=cluster_config["scheduler_instance_type"],
    auto_shutdown=False,
    shutdown_on_close=False,
    security=False,  # https://github.com/dask/dask-cloudprovider/issues/249,
    volume_tags=cluster_config["ec2_instance_tags"],
    worker_instance_type="m5.2xlarge",
)
```
creates an `EC2Cluster` with 10 m5.2xlarge worker machines and a total of 40 workers (as `num_workers_per_vm` = 4).