### PR TITLE
Ensure workers use private ip to connect to scheduler

### DIFF
--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -217,7 +217,7 @@ class EC2Instance(VMInterface):
             await asyncio.sleep(min(backoff, 10) + backoff % 1)
             # Exponential backoff with a cap of 10 seconds and some jitter
             backoff = backoff * 2
-        return self.instance[ip_address_key]
+        return self.instance[ip_address_key], None
 
     async def destroy_vm(self):
         boto_config = botocore.config.Config(retries=dict(max_attempts=10))

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -14,8 +14,6 @@ from dask_cloudprovider.generic.vmcluster import (
 from dask_cloudprovider.exceptions import ConfigError
 from dask_cloudprovider.azure.utils import _get_default_subscription
 
-from distributed.core import Status
-
 try:
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.compute import ComputeManagementClient
@@ -246,43 +244,9 @@ class AzureVM(VMInterface):
 class AzureVMScheduler(SchedulerMixin, AzureVM):
     """Scheduler running on an Azure VM."""
 
-    def __init__(self, *args, **kwargs):
-        kwargs.pop("preemptible", None)
-        super().__init__(*args, **kwargs)
-
-    async def start(self):
-        await self.start_scheduler()
-        self.status = Status.running
-
-    async def start_scheduler(self):
-        self.cluster._log("Creating scheduler instance")
-
-        internal_ip, external_ip = await self.create_vm()
-
-        self.address = f"{self.cluster.protocol}://{internal_ip}:{self.port}"
-
-        if external_ip is not None:
-            self.external_address = (
-                f"{self.cluster.protocol}://{external_ip}:{self.port}"
-            )
-        else:
-            self.external_address = None
-
-        await self.wait_for_scheduler()
-
 
 class AzureVMWorker(WorkerMixin, AzureVM):
     """Worker running on an AzureVM."""
-
-    async def start(self):
-        await self.start_worker()
-        self.status = Status.running
-
-    async def start_worker(self):
-        self.cluster._log("Creating worker instance")
-
-        internal_ip, _ = await self.create_vm()
-        self.address = internal_ip
 
 
 class AzureVMCluster(VMCluster):

--- a/dask_cloudprovider/azure/azurevm.py
+++ b/dask_cloudprovider/azure/azurevm.py
@@ -14,6 +14,8 @@ from dask_cloudprovider.generic.vmcluster import (
 from dask_cloudprovider.exceptions import ConfigError
 from dask_cloudprovider.azure.utils import _get_default_subscription
 
+from distributed.core import Status
+
 try:
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.compute import ComputeManagementClient
@@ -200,9 +202,12 @@ class AzureVM(VMInterface):
             self.nic.name,
         )
         self.cluster._log(f"Created VM {self.name}")
+
+        private_ip_address = self.nic.ip_configurations[0].private_ip_address
         if self.public_ingress:
-            return self.public_ip.ip_address
-        return self.nic.ip_configurations[0].private_ip_address
+            return private_ip_address, self.public_ip.ip_address
+        else:
+            return private_ip_address, None
 
     async def destroy_vm(self):
         await self.cluster.call_async(
@@ -241,9 +246,43 @@ class AzureVM(VMInterface):
 class AzureVMScheduler(SchedulerMixin, AzureVM):
     """Scheduler running on an Azure VM."""
 
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("preemptible", None)
+        super().__init__(*args, **kwargs)
+
+    async def start(self):
+        await self.start_scheduler()
+        self.status = Status.running
+
+    async def start_scheduler(self):
+        self.cluster._log("Creating scheduler instance")
+
+        internal_ip, external_ip = await self.create_vm()
+
+        self.address = f"{self.cluster.protocol}://{internal_ip}:{self.port}"
+
+        if external_ip is not None:
+            self.external_address = (
+                f"{self.cluster.protocol}://{external_ip}:{self.port}"
+            )
+        else:
+            self.external_address = None
+
+        await self.wait_for_scheduler()
+
 
 class AzureVMWorker(WorkerMixin, AzureVM):
     """Worker running on an AzureVM."""
+
+    async def start(self):
+        await self.start_worker()
+        self.status = Status.running
+
+    async def start_worker(self):
+        self.cluster._log("Creating worker instance")
+
+        internal_ip, _ = await self.create_vm()
+        self.address = internal_ip
 
 
 class AzureVMCluster(VMCluster):

--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -66,7 +66,7 @@ class Droplet(VMInterface):
             await asyncio.sleep(0.1)
         self.cluster._log(f"Created droplet {self.name}")
 
-        return self.droplet.ip_address
+        return self.droplet.ip_address, None
 
     async def destroy_vm(self):
         await self.cluster.call_async(self.droplet.destroy)

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -87,7 +87,7 @@ class SchedulerMixin(object):
         )
 
     async def start(self):
-        self.cluster._log("Creating scheduler instance MIXIN version")
+        self.cluster._log("Creating scheduler instance")
 
         internal_ip, external_ip = await self.create_vm()
         self.address = f"{self.cluster.protocol}://{internal_ip}:{self.port}"
@@ -154,7 +154,7 @@ class WorkerMixin(object):
             )
 
     async def start(self):
-        self.cluster._log("Creating worker instance MIXIN")
+        self.cluster._log("Creating worker instance")
         self.address, _ = await self.create_vm()
         await super().start()
 

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -43,7 +43,10 @@ class VMInterface(ProcessInterface):
         raise NotImplementedError("destroy_vm is a required method of the VMInterface")
 
     async def wait_for_scheduler(self):
-        _, address = self.address.split("://")
+        if getattr(self, "external_address", None):
+            _, address = self.external_address.split("://")
+        else:
+            _, address = self.address.split("://")
         ip, port = address.split(":")
 
         self.cluster._log(f"Waiting for scheduler to run at {ip}:{port}")

--- a/dask_cloudprovider/hetzner/vserver.py
+++ b/dask_cloudprovider/hetzner/vserver.py
@@ -66,7 +66,7 @@ class VServer(VMInterface):
                 await asyncio.sleep(0.1)
         self.cluster._log(f"Created Hetzner vServer {self.name}")
 
-        return self.server.public_net.ipv4.ip
+        return self.server.public_net.ipv4.ip, None
 
     async def destroy_vm(self):
         await self.cluster.call_async(self.client.servers.delete, server=self.server)


### PR DESCRIPTION
Intended to address [#254](https://github.com/dask/dask-cloudprovider/issues/254)

**Overview**
Let the scheduler and dashboard be publicly adressable with the workers in a vnet. The workers will always connect to the scheduler using the private IP, regardless of whether the scheduler has a public IP or not.

- `self.address` is the private IP
- `self.external_address` is the public IP on the scheduler object if public_ingress=True

**Testing**
Confirmed that it works by creating a cluster with `public_ingress = True` and a vnet allowing traffic on ports 8786-8787 from IP of local laptop only. Without this fix, the workers try to communicate with the scheduler using the public IP.