### PR TITLE
Link to central deploying Dask page

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,6 +6,8 @@ Dask Cloud Provider
 This package provides classes for constructing and managing ephemeral Dask clusters on various
 cloud platforms.
 
+Dask Cloud Provider is one of many options for deploying Dask clusters, see `Deploying Dask <https://docs.dask.org/en/stable/deploying.html#distributed-computing>`_ in the Dask documentation for an overview of additional options.
+
 To use a cloud provider cluster manager you can import it and instantiate it. Instantiating the class
 will result in cloud resources being created for you.
 


### PR DESCRIPTION
In https://github.com/dask/dask/pull/9912, the organization of links for deploying options in [Deploy Dask Clusters](https://docs.dask.org/en/stable/deploying.html) was improved and we discussed linking to this central page in other projects.

cc @jacobtomlinson @gjoseph92 