### PR TITLE
Bump flake8 and black in pre-commit config and add support for 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.10.1
     hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.1.0
     hooks:
       - id: flake8
         language_version: python3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,4 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.11"

--- a/ci/environment-3.11.yml
+++ b/ci/environment-3.11.yml
@@ -1,0 +1,38 @@
+name: dask-cloudprovider-test
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.11
+  - nomkl
+  - pip
+  # Dask
+  - dask
+  # testing / CI
+  - flake8
+  - ipywidgets
+  - pytest
+  - pytest-asyncio
+  - black >=20.8b1
+  - pyyaml
+  # dask dependencies
+  - cloudpickle
+  - toolz
+  - cytoolz
+  - numpy
+  - partd
+  # distributed dependencies
+  - click >=6.6
+  - msgpack-python
+  - psutil >=5.0
+  - six
+  - sortedcontainers !=2.0.0,!=2.0.1
+  - tblib
+  - tornado >=5
+  - zict >=0.1.3
+  # `event_loop_policy` change See https://github.com/dask/distributed/pull/4212
+  - pytest-asyncio >=0.14.0
+  - pytest-timeout
+  - pip:
+      - git+https://github.com/dask/dask.git@main
+      - git+https://github.com/dask/distributed@main

--- a/dask_cloudprovider/azure/tests/test_azurevm.py
+++ b/dask_cloudprovider/azure/tests/test_azurevm.py
@@ -66,7 +66,6 @@ async def test_create_cluster():
 @skip_without_credentials
 @pytest.mark.external
 async def test_create_cluster_sync():
-
     with AzureVMCluster() as cluster:
         with Client(cluster) as client:
             cluster.scale(1)
@@ -84,7 +83,6 @@ async def test_create_cluster_sync():
 @skip_without_credentials
 @pytest.mark.external
 async def test_create_rapids_cluster_sync():
-
     with AzureVMCluster(
         vm_size="Standard_NC12s_v3",
         docker_image="rapidsai/rapidsai:cuda11.0-runtime-ubuntu18.04-py3.9",

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -110,7 +110,6 @@ class GCPInstance(VMInterface):
         self.service_account = service_account or self.config.get("service_account")
 
     def create_gcp_config(self):
-
         subnetwork = f"projects/{self.network_projectid}/regions/{self.general_zone}/subnetworks/{self.network}"
         config = {
             "name": self.name,
@@ -205,7 +204,6 @@ class GCPInstance(VMInterface):
         return config
 
     async def create_vm(self):
-
         self.cloud_init = self.cluster.render_process_cloud_init(self)
 
         self.gcp_config = self.create_gcp_config()
@@ -591,7 +589,6 @@ class GCPCluster(VMCluster):
         service_account=None,
         **kwargs,
     ):
-
         self.compute = GCPCompute()
 
         self.config = dask.config.get("cloudprovider.gcp", {})
@@ -650,7 +647,6 @@ class GCPCompute:
         self._compute = self.refresh_client()
 
     def refresh_client(self):
-
         if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", False):
             import google.oauth2.service_account  # google-auth
 

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -76,7 +76,6 @@ async def test_create_cluster():
     async with GCPCluster(
         asynchronous=True, env_vars={"FOO": "bar"}, security=True
     ) as cluster:
-
         assert cluster.status == Status.running
 
         cluster.scale(2)
@@ -132,7 +131,6 @@ async def test_create_rapids_cluster():
         auto_shutdown=True,
         bootstrap=False,
     ) as cluster:
-
         assert cluster.status == Status.running
 
         cluster.scale(1)

--- a/versioneer.py
+++ b/versioneer.py
@@ -343,9 +343,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
This fixes pre-commit failure https://github.com/dask/dask-cloudprovider/actions/runs/6709474379/job/18232600682

It looks like the default python version in the action was bumped to the latest 3.12. **flake8** in version `3.9.2` does not work with python3.12.
I've bumped the **flake8** and **black** to the latest versions. The new **black** formatter removed a few empty lines.

I've also added a support for python 3.11 and preliminary support for 3.12. Before supporting 3.12 we have to wait for a new aiohttp version https://github.com/aio-libs/aiohttp/issues/7675