### PR TITLE
[aws] add docs on cpu_architecture for ECSCluster

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -485,7 +485,10 @@ class ECSCluster(SpecCluster, ConfigMixin):
 
         Defaults to ``daskdev/dask:latest`` or ``rapidsai/rapidsai:latest`` if ``worker_gpu`` is set.
     cpu_architecture: str (optional)
-        Runtime platform CPU architecture
+        Runtime platform CPU architecture.
+        Typically either ``X86_64`` or ``ARM64``.
+        Valid values are documented here:
+        https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-tasks-services.html#fargate-task-os
 
         Defaults to ``X86_64``.
     scheduler_cpu: int (optional)


### PR DESCRIPTION
Using `FargateCluster` tonight, I found myself wanting to create a cluster using arm64 servers, because I was working with container images that were only built from arm64.

Thankfully, as of #425, that's now configurable easily via the `cpu_architecture` argument 🎉 

... but I didn't know what the valid values were for that. `arm64`? `aarch64`? does capitalization matter?

This proposes adding a link to the relevant AWS docs to help answer that question.

## Notes for Reviewers

Tested `cpu_architecture="ARM64"` tonight and it worked great 😁 

ref: https://github.com/jameslamb/lightgbm-dask-testing/pull/68