### PR TITLE
Update Nebius dependency to versioned release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     "hetzner": ["hcloud>=1.10.0"],
     "ibm": ["ibm_code_engine_sdk>=3.1.0"],
     "openstack": ["openstacksdk>=3.3.0"],
-    "nebius": ["nebius @ git+https://github.com/nebius/pysdk"],
+    "nebius": ["nebius>=0.2.0"],
 }
 extras_require["all"] = set(pkg for pkgs in extras_require.values() for pkg in pkgs)
 


### PR DESCRIPTION
Replaced Git-based dependency for Nebius with a versioned package (`nebius>=0.2.0`) for better stability and compatibility. This ensures easier management of dependencies and aligns with standard versioning practices.