### PR TITLE
Fix issue 390 support different machine types on gcp

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -101,7 +101,9 @@ cloudprovider:
     network_projectid: null # GCP project id where the network exists
     projectid: "" # name of the google cloud project
     on_host_maintenance: "TERMINATE"
-    machine_type: "n1-standard-1" # size of the machine type to use
+    machine_type: "n1-standard-1" # size of the machine type to use for the scheduler and all workers
+    scheduler_machine_type: "n1-standard-1" # size of the machine type to use for the scheduler
+    worker_machine_type: "n1-standard-1" # size of the machine type to use for all workers
     filesystem_size: 50 # amount in GBs of hard drive space to allocate
     ngpus: "" # number of GPUs to use
     gpu_type: "" # type of gpus to use: nvidia-tesla-k80, nvidia-tesla-p100, nvidia-tesla-t4

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -618,9 +618,7 @@ class GCPCluster(VMCluster):
             self.worker_machine_type = worker_machine_type or self.config.get("worker_machine_type")
         else:
             if scheduler_machine_type is not None or worker_machine_type is not None:
-                raise ValueError(
-                    "If you specify machine_type, you may not specify scheduler_machine_type or worker_machine_type"
-                )
+                raise ValueError("If you specify machine_type, you may not specify scheduler_machine_type or worker_machine_type")
             self.scheduler_machine_type = machine_type
             self.worker_machine_type = machine_type
         self.gpu_instance = "gpu" in self.machine_type or bool(ngpus)
@@ -659,6 +657,15 @@ class GCPCluster(VMCluster):
         self.worker_options = {**self.options}
         self.scheduler_options["machine_type"] = self.scheduler_machine_type
         self.worker_options["machine_type"] = self.worker_machine_type
+
+        if ngpus is not None:
+            self.scheduler_options["ngpus"] = 0
+            self.scheduler_options["gpu_type"] = None
+
+            self.worker_ngpus = ngpus
+            self.worker_options["ngpus"] = ngpus or self.config.get("ngpus"),
+            self.worker_options["gpu_type"] = gpu_type or self.config.get("gpu_type"),
+            self.worker_options["gpu_instance"] = True
 
         if "extra_bootstrap" not in kwargs:
             kwargs["extra_bootstrap"] = self.config.get("extra_bootstrap")

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -621,7 +621,6 @@ class GCPCluster(VMCluster):
                 raise ValueError("If you specify machine_type, you may not specify scheduler_machine_type or worker_machine_type")
             self.scheduler_machine_type = machine_type
             self.worker_machine_type = machine_type
-        self.gpu_instance = "gpu" in self.machine_type or bool(ngpus)
         self.debug = debug
         self.options = {
             "cluster": self,
@@ -661,6 +660,7 @@ class GCPCluster(VMCluster):
         if ngpus is not None:
             self.scheduler_options["ngpus"] = 0
             self.scheduler_options["gpu_type"] = None
+            self.scheduler_options["gpu_instance"] = False
 
             self.worker_ngpus = ngpus
             self.worker_options["ngpus"] = ngpus or self.config.get("ngpus"),

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -663,8 +663,8 @@ class GCPCluster(VMCluster):
             self.scheduler_options["gpu_instance"] = False
 
             self.worker_ngpus = ngpus
-            self.worker_options["ngpus"] = ngpus or self.config.get("ngpus"),
-            self.worker_options["gpu_type"] = gpu_type or self.config.get("gpu_type"),
+            self.worker_options["ngpus"] = ngpus or self.config.get("ngpus")
+            self.worker_options["gpu_type"] = gpu_type or self.config.get("gpu_type")
             self.worker_options["gpu_instance"] = True
 
         if "extra_bootstrap" not in kwargs:


### PR DESCRIPTION
As per https://github.com/dask/dask-cloudprovider/issues/390, there is a feature request for allowing to choose different machine types on GCP. Here I tried to implement that, and make only the workers to use GPU. 

I used https://github.com/dask/dask-cloudprovider/pull/369 as a reference