### PR TITLE
Remove calls to `self.cluster.call_async()`

### DIFF
--- a/dask_cloudprovider/digitalocean/droplet.py
+++ b/dask_cloudprovider/digitalocean/droplet.py
@@ -56,20 +56,20 @@ class Droplet(VMInterface):
             backups=False,
             user_data=self.cluster.render_process_cloud_init(self),
         )
-        await self.cluster.call_async(self.droplet.create)
+        await self.call_async(self.droplet.create)
         for action in self.droplet.get_actions():
             while action.status != "completed":
                 action.load()
                 await asyncio.sleep(0.1)
         while self.droplet.ip_address is None:
-            await self.cluster.call_async(self.droplet.load)
+            await self.call_async(self.droplet.load)
             await asyncio.sleep(0.1)
         self.cluster._log(f"Created droplet {self.name}")
 
         return self.droplet.ip_address, None
 
     async def destroy_vm(self):
-        await self.cluster.call_async(self.droplet.destroy)
+        await self.call_async(self.droplet.destroy)
         self.cluster._log(f"Terminated droplet {self.name}")
 
 

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -206,7 +206,7 @@ class GCPInstance(VMInterface):
         self.gcp_config = self.create_gcp_config()
 
         try:
-            inst = await self.cluster.call_async(
+            inst = await self.call_async(
                 self.cluster.compute.instances()
                 .insert(project=self.projectid, zone=self.zone, body=self.gcp_config)
                 .execute
@@ -232,7 +232,7 @@ class GCPInstance(VMInterface):
 
     async def get_internal_ip(self):
         return (
-            await self.cluster.call_async(
+            await self.call_async(
                 self.cluster.compute.instances()
                 .list(
                     project=self.projectid, zone=self.zone, filter=f"name={self.name}"
@@ -243,7 +243,7 @@ class GCPInstance(VMInterface):
 
     async def get_external_ip(self):
         return (
-            await self.cluster.call_async(
+            await self.call_async(
                 self.cluster.compute.instances()
                 .list(
                     project=self.projectid, zone=self.zone, filter=f"name={self.name}"
@@ -253,7 +253,7 @@ class GCPInstance(VMInterface):
         )["items"][0]["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
 
     async def update_status(self):
-        d = await self.cluster.call_async(
+        d = await self.call_async(
             self.cluster.compute.instances()
             .list(project=self.projectid, zone=self.zone, filter=f"name={self.name}")
             .execute
@@ -276,7 +276,7 @@ class GCPInstance(VMInterface):
 
     async def close(self):
         self.cluster._log(f"Closing Instance: {self.name}")
-        await self.cluster.call_async(
+        await self.call_async(
             self.cluster.compute.instances()
             .delete(project=self.projectid, zone=self.zone, instance=self.name)
             .execute

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -65,7 +65,7 @@ class VMInterface(ProcessInterface):
 
     async def call_async(self, f, *args, **kwargs):
         """Run a blocking function in a thread as a coroutine."""
-        return await self.cluster.call_async(f, *args, **kwargs)
+        return await self.call_async(f, *args, **kwargs)
 
 
 class SchedulerMixin(object):

--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -63,6 +63,10 @@ class VMInterface(ProcessInterface):
         await self.destroy_vm()
         await super().close()
 
+    async def call_async(self, f, *args, **kwargs):
+        """Run a blocking function in a thread as a coroutine."""
+        return await self.cluster.call_async(f, *args, **kwargs)
+
 
 class SchedulerMixin(object):
     """A mixin for Schedulers."""

--- a/dask_cloudprovider/hetzner/vserver.py
+++ b/dask_cloudprovider/hetzner/vserver.py
@@ -51,7 +51,7 @@ class VServer(VMInterface):
         self.docker_image = docker_image
 
     async def create_vm(self):
-        await self.cluster.call_async(
+        await self.call_async(
             self.client.servers.create,
             server_type=self.server_type,
             image=self.image,
@@ -62,14 +62,14 @@ class VServer(VMInterface):
         self.server = self.client.servers.get_by_name(self.name)
         for action in self.server.get_actions():
             while action.status != Action.STATUS_SUCCESS:
-                await self.cluster.call_async(action.reload)
+                await self.call_async(action.reload)
                 await asyncio.sleep(0.1)
         self.cluster._log(f"Created Hetzner vServer {self.name}")
 
         return self.server.public_net.ipv4.ip, None
 
     async def destroy_vm(self):
-        await self.cluster.call_async(self.client.servers.delete, server=self.server)
+        await self.call_async(self.client.servers.delete, server=self.server)
         self.cluster._log(f"Terminated vServer {self.name}")
 
 

--- a/dask_cloudprovider/openstack/instances.py
+++ b/dask_cloudprovider/openstack/instances.py
@@ -111,13 +111,13 @@ class OpenStackInstance(VMInterface):
         """Create and assign a floating IP to the instance."""
         try:
             # Create a floating IP
-            floating_ip = await self.cluster.call_async(
+            floating_ip = await self.call_async(
                 conn.network.create_ip,
                 floating_network_id=self.config["external_network_id"],
             )
 
             # Find the first port of the instance
-            ports = await self.cluster.call_async(
+            ports = await self.call_async(
                 conn.network.ports,
                 device_id=self.instance.id
             )
@@ -126,7 +126,7 @@ class OpenStackInstance(VMInterface):
                 raise RuntimeError(f"No network ports found for instance {self.instance.id}")
 
             # Assign the floating IP to the instance's port
-            await self.cluster.call_async(
+            await self.call_async(
                 conn.network.update_ip,
                 floating_ip,
                 port_id=ports[0].id
@@ -170,7 +170,7 @@ class OpenStackInstance(VMInterface):
         try:
             instance = conn.compute.get_server(self.instance.id)
             if instance:
-                await self.cluster.call_async(conn.compute.delete_server, instance.id)
+                await self.call_async(conn.compute.delete_server, instance.id)
                 self.cluster._log(f"Terminated instance {self.name}")
             else:
                 self.cluster._log(f"Instance {self.name} not found or already deleted.")


### PR DESCRIPTION
Currently the implementations of `VMInterface` call `self.cluster.call_async()` when they want to run a synchronous function. This reference to the parent cluster instance means that `VMInterface` instances can't exist outside of a cluster.

This PR adds a `VMInterface.call_async` method which encapsulates the call to `self.cluster.call_async()`. This allows others to override this method if they wish more easily.