### PR TITLE
Better avoid and handle AWS API throttling

### DIFF
--- a/dask_cloudprovider/utils/timeout.py
+++ b/dask_cloudprovider/utils/timeout.py
@@ -66,7 +66,7 @@ class Timeout:
             self.start = datetime.now()
             self.running = True
 
-        if self.start + timedelta(seconds=self.timeout) < datetime.now():
+        if self.elapsed_time >= self.timeout:
             if self.warn:
                 warnings.warn(self.error_message)
                 return False
@@ -82,3 +82,10 @@ class Timeout:
         the thing you are trying rather than a TimeoutException.
         """
         self.exception = e
+
+    @property
+    def elapsed_time(self):
+        """Return the elapsed time since the timeout started."""
+        if self.start is None:
+            return 0
+        return (datetime.now() - self.start).total_seconds()


### PR DESCRIPTION
The current ECS implementation has a couple issues regarding AWS API throttling that are especially problematic when starting a large cluster (over ~100 workers)

- API calls are not used efficiently. For example each `Worker` makes its own call to `ecs.list_account_settings` to determine if `taskLongArnFormat` is enabled rather than doing this just once at the `ECSCluster` level. This PR optimized some of the easy cases like this. The most notable one that's NOT addressed is `ecs.describe_tasks` that each worker polls as it's waiting to come up.
- Throttle backoff handling is not implemented for all API calls that need it and none of them implement jittered backoff which leads to many workers backing off at exactly the same rate and all making their retry requests at the same time. The solution I have implemented here is to leverage the [backoff support built into boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html) that uses jittered exponential backoff.

References:
- [ECS throttling quotas](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/request-throttling.html#throttling-quotas)