### PR TITLE
[Openstack Cloud Provider] Added command option to OpenStackInstance to run custom commands

### DIFF
--- a/dask_cloudprovider/openstack/instances.py
+++ b/dask_cloudprovider/openstack/instances.py
@@ -32,6 +32,7 @@ class OpenStackInstance(VMInterface):
         docker_image: str = None,
         env_vars: str = None,
         extra_bootstrap: str = None,
+        command: str = None, 
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -45,6 +46,7 @@ class OpenStackInstance(VMInterface):
         self.bootstrap = True
         self.docker_image = docker_image
         self.extra_bootstrap = extra_bootstrap
+        self.command = command  # Command to run on the instance, if any
 
     async def create_vm(self):
         conn = connection.Connection(


### PR DESCRIPTION
Hello all

Adding support to run custom commands on OpenStackInstance Dask Workers. This will be parsed into the cloud-init

```
  - 'docker run --net=host {%+ if gpu_instance %}--gpus=all{% endif %} {% for key in env_vars %} -e {{key}}="{{env_vars[key]}}" {% endfor %}{%+ if docker_args %}{{docker_args}}{% endif %} {{image}} {{ command }}'
```