### PR TITLE
Fixing the log error

### DIFF
--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -650,7 +650,7 @@ class GCPCluster(VMCluster):
             self.scheduler_ngpus = scheduler_ngpus if scheduler_ngpus is not None else self.config.get("scheduler_ngpus", 0)
             self.worker_ngpus = worker_ngpus if worker_ngpus is not None else self.config.get("worker_ngpus", 0)
             if self.scheduler_ngpus == 0 and self.worker_ngpus == 0:
-                self._log("No GPU instances configured")
+                print("No GPU instances configured")
         else:
             if scheduler_ngpus is not None or worker_ngpus is not None:
                 raise ValueError("If you specify ngpus, you may not specify scheduler_ngpus or worker_ngpus")

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -649,8 +649,6 @@ class GCPCluster(VMCluster):
         if not self.ngpus:
             self.scheduler_ngpus = scheduler_ngpus if scheduler_ngpus is not None else self.config.get("scheduler_ngpus", 0)
             self.worker_ngpus = worker_ngpus if worker_ngpus is not None else self.config.get("worker_ngpus", 0)
-            if self.scheduler_ngpus == 0 and self.worker_ngpus == 0:
-                print("No GPU instances configured")
         else:
             if scheduler_ngpus is not None or worker_ngpus is not None:
                 raise ValueError("If you specify ngpus, you may not specify scheduler_ngpus or worker_ngpus")
@@ -712,6 +710,9 @@ class GCPCluster(VMCluster):
             kwargs["extra_bootstrap"] = self.config.get("extra_bootstrap")
 
         super().__init__(debug=debug, **kwargs)
+
+        if not self.ngpus and (self.scheduler_ngpus == 0 and self.worker_ngpus == 0):
+            self._log("No GPU instances configured")
 
 
 class GCPCompute:


### PR DESCRIPTION
While working on the issue 390 in [this PR](https://github.com/dask/dask-cloudprovider/pull/451), it appears I have made a mistake with the logging "No GPU instances configured" message. The GCPCluster does not have any loggers, so it is better to just make a print statement.