### PR TITLE
Workers should use internal IP addresses to communicate with scheduler

### DIFF
--- a/dask_cloudprovider/generic/vmcluster.py
+++ b/dask_cloudprovider/generic/vmcluster.py
@@ -99,6 +99,8 @@ class SchedulerMixin(object):
                 f"{self.cluster.protocol}://{external_ip}:{self.port}"
             )
 
+        self.contact_address = f"{self.cluster.protocol}://{internal_ip}:{self.port}"
+
         await self.wait_for_scheduler()
         await super().start()
 


### PR DESCRIPTION
The EC2 provider does not use internal IP addresses for  worker-to-scheduler communication:
https://github.com/dask/dask-cloudprovider/issues/254#issuecomment-3048336643

Instead, they route all requests via a public IP if it leads to a problem that we can not set up security group with restriction to specific IP addresses. 