### PR TITLE
Add tags parameter to create_default_security_group function

### DIFF
--- a/dask_cloudprovider/aws/ecs.py
+++ b/dask_cloudprovider/aws/ecs.py
@@ -1163,7 +1163,7 @@ class ECSCluster(SpecCluster, ConfigMixin):
     async def _create_security_groups(self):
         async with self._client("ec2") as client:
             group = await create_default_security_group(
-                client, self.cluster_name, self._vpc
+                client, self.cluster_name, self._vpc, self.tags
             )
         weakref.finalize(self, self.sync, self._delete_security_groups)
         return [group]

--- a/dask_cloudprovider/aws/helper.py
+++ b/dask_cloudprovider/aws/helper.py
@@ -1,4 +1,5 @@
 """Helper functions for working with AWS services."""
+
 from datetime import datetime
 
 DEFAULT_SECURITY_GROUP_NAME = "dask-default"
@@ -93,11 +94,21 @@ async def get_security_group(client, vpc, create_default=True):
             )
 
 
-async def create_default_security_group(client, group_name, vpc):
+async def create_default_security_group(client, group_name, vpc, tags):
     response = await client.create_security_group(
         Description="A default security group for Dask",
         GroupName=group_name,
         VpcId=vpc,
+        TagSpecifications=[
+            {
+                "ResourceType": "security-group",
+                "Tags": [
+                    {"Key": k, "Value": v}
+                    for k, v in (tags or {}).items()
+                    if k and v  # Filter out empty tags
+                ],
+            }
+        ],
         DryRun=False,
     )
 


### PR DESCRIPTION
Introduce a tags parameter to the `create_default_security_group` function, allowing the specification of tags when creating a default security group. This enables the `_cleanup_stale_resources` to capture those security groups which would otherwise be left untouched in the cleanup process.