### PR TITLE
Introduce unique IDs for Dask clusters running in the same ECS cluster.

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -17,7 +17,7 @@ cloudprovider:
     image: "daskdev/dask:latest" # Docker image to use for non GPU tasks
     cpu_architecture: "X86_64" # Runtime platform CPU architecture
     gpu_image: "rapidsai/rapidsai:latest" # Docker image to use for GPU tasks
-    cluster_name_template: "dask-{uuid}" # Template to use when creating a cluster
+    cluster_name_template: "dask-{dask_cluster_id}" # Template to use when creating a cluster
     cluster_arn: "" # ARN of existing ECS cluster to use (if not set one will be created)
     execution_role_arn: "" # Arn of existing execution role to use (if not set one will be created)
     task_role_arn: "" # Arn of existing task role to use (if not set one will be created)
@@ -25,7 +25,7 @@ cloudprovider:
     #   platform_version: "LATEST" # Fargate platformVersion string like "1.4.0" or "LATEST"
 
     cloudwatch_logs_group: "" # Name of existing cloudwatch logs group to use (if not set one will be created)
-    cloudwatch_logs_stream_prefix: "{cluster_name}" # Stream prefix template
+    cloudwatch_logs_stream_prefix: "{cluster_name}/{dask_cluster_id}" # Stream prefix template
     cloudwatch_logs_default_retention: 30 # Number of days to retain logs (only applied if not using existing group)
 
     vpc: "default" # VPC to use for tasks


### PR DESCRIPTION
Addresses https://github.com/dask/dask-cloudprovider/issues/472 by assigning a unique ID to all Dask clusters and using that within the names and tags for all associated resources.

Previously, cluster_name was used for this purpose, but when running multiple Dask clusters on the same pre-existing ECS cluster this could cause name collisions.

This patch resolves the collision situation and also makes resources associated with an individual Dask cluster much easier to identify.