### PR TITLE
Fix for breaking change in gcp cluster "TypeError: '>' not supported between instances of 'str' and 'int'"

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -105,12 +105,12 @@ cloudprovider:
     scheduler_machine_type: "n1-standard-1" # size of the machine type to use for the scheduler
     worker_machine_type: "n1-standard-1" # size of the machine type to use for all workers
     filesystem_size: 50 # amount in GBs of hard drive space to allocate
-    ngpus: "" # number of GPUs to use. If provided, will be used for both scheduler and worker
-    gpu_type: "" # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``. If provided, will be used for both scheduler and worker
-    scheduler_ngpus: "" # number of GPUs to use on scheduler
-    scheduler_gpu_type: "" # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``.
-    worker_ngpus: "" # number of GPUs to use on worker
-    worker_gpu_type: "" # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``.
+    ngpus: null # number of GPUs to use. If provided, will be used for both scheduler and worker
+    gpu_type: null # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``. If provided, will be used for both scheduler and worker
+    scheduler_ngpus: null # number of GPUs to use on scheduler
+    scheduler_gpu_type: null # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``.
+    worker_ngpus: null # number of GPUs to use on worker
+    worker_gpu_type: null # type of gpus to use. (e.g. 'nvidia-tesla-t4'). You can view the possible values through ``gcloud compute accelerator-types list``.
     disk_type: "pd-standard" # type of disk to use: pd-standard, pd-ssd
     docker_image: "daskdev/dask:latest" # docker image to use
     auto_shutdown: true # Shutdown instances automatically if the scheduler or worker services time out.

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -662,17 +662,18 @@ class GCPCluster(VMCluster):
             self.scheduler_machine_type = machine_type
             self.worker_machine_type = machine_type
 
-        self.ngpus = ngpus or self.config.get("ngpus")
+        ngpus_value = ngpus or self.config.get("ngpus")
+        self.ngpus = int(ngpus_value) if ngpus_value else None
         if not self.ngpus:
             self.scheduler_ngpus = (
                 scheduler_ngpus
                 if scheduler_ngpus is not None
-                else self.config.get("scheduler_ngpus", 0)
+                else int(self.config.get("scheduler_ngpus") or 0)
             )
             self.worker_ngpus = (
                 worker_ngpus
                 if worker_ngpus is not None
-                else self.config.get("worker_ngpus", 0)
+                else int(self.config.get("worker_ngpus") or 0)
             )
         else:
             if scheduler_ngpus is not None or worker_ngpus is not None:

--- a/dask_cloudprovider/gcp/instances.py
+++ b/dask_cloudprovider/gcp/instances.py
@@ -662,18 +662,17 @@ class GCPCluster(VMCluster):
             self.scheduler_machine_type = machine_type
             self.worker_machine_type = machine_type
 
-        ngpus_value = ngpus or self.config.get("ngpus")
-        self.ngpus = int(ngpus_value) if ngpus_value else None
+        self.ngpus = ngpus or self.config.get("ngpus")
         if not self.ngpus:
             self.scheduler_ngpus = (
                 scheduler_ngpus
                 if scheduler_ngpus is not None
-                else int(self.config.get("scheduler_ngpus") or 0)
+                else self.config.get("scheduler_ngpus") or 0
             )
             self.worker_ngpus = (
                 worker_ngpus
                 if worker_ngpus is not None
-                else int(self.config.get("worker_ngpus") or 0)
+                else self.config.get("worker_ngpus") or 0
             )
         else:
             if scheduler_ngpus is not None or worker_ngpus is not None:

--- a/dask_cloudprovider/gcp/tests/test_gcp.py
+++ b/dask_cloudprovider/gcp/tests/test_gcp.py
@@ -54,6 +54,17 @@ async def test_init():
 
 
 @pytest.mark.asyncio
+async def test_init_gpu_config_defaults():
+    """Regression test for https://github.com/dask/dask-cloudprovider/pull/479."""
+    skip_without_credentials()
+
+    cluster = GCPCluster(asynchronous=True)
+    assert cluster.ngpus is None
+    assert cluster.scheduler_ngpus == 0
+    assert cluster.worker_ngpus == 0
+
+
+@pytest.mark.asyncio
 async def test_get_cloud_init():
     skip_without_credentials()
     cloud_init = GCPCluster.get_cloud_init(


### PR DESCRIPTION
- Default config values for ngpus, scheduler_ngpus and worker_ngpus are now converted to integers before being checked to be greater than the value of zero. 
- Beforehand, these values were assumed to be integers, causing a type error for all instantiations of GCPCluster, creating a breaking change
- I would suggest a new release of dask cloud provider (after tests) as this currently breaks the GCPCluster