### PR TITLE
Ensure latest dask-sphinx-theme

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,4 +19,4 @@ submodules:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"

--- a/dask_cloudprovider/aws/ec2.py
+++ b/dask_cloudprovider/aws/ec2.py
@@ -455,7 +455,7 @@ class EC2Cluster(VMCluster):
     ...                      bootstrap=False,
     ...                      filesystem_size=120,
     ...                      env_vars=get_aws_credentials()) # Pass credentials to Cluster see Notes section for info
-=======
+
 
     Enable SSH for debugging
 

--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,14 +1,4 @@
-# We have to set minimal versions to avoid searches over old versions whose metadata is incompatible with the latest pip
-numpydoc<2,>=1.5.0
-docutils<0.17,>=0.16
-sphinx<5,>=4.0.0
-dask-sphinx-theme<4,>=3.0.5
-# FIXME: This workaround is required until we have sphinx>=5, as enabled by
-#        dask-sphinx-theme no longer pinning sphinx-book-theme==0.2.0. This is
-#        tracked in https://github.com/dask/dask-sphinx-theme/issues/68.
-#
-sphinxcontrib-applehelp<1.0.5,>=1.0.0
-sphinxcontrib-devhelp<1.0.6,>=1.0.0
-sphinxcontrib-htmlhelp<2.0.5,>=2.0.0
-sphinxcontrib-serializinghtml<1.1.10,>=1.0.0
-sphinxcontrib-qthelp<1.0.7,>=1.0.0
+numpydoc
+docutils
+sphinx>=8
+dask-sphinx-theme>=4.0.0

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,7 +78,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -112,7 +112,7 @@ html_theme = "dask_sphinx_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
- Removed pins from #468 to allow docs builds with newer Sphinx versions now that we have `dask-sphinx-theme` version `4`.
- Removed divider in examples that is causing rubric error
- Explicitly set language and removed unused static directory

xref https://github.com/dask/dask-sphinx-theme/issues/68#issuecomment-1893198477